### PR TITLE
[FAB-16959] Update CLI to latest fabric-sdk-go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,3 +24,10 @@ linters:
 linters-settings:
   lll:
     line-length: 150
+
+issues:
+  exclude-rules:
+    # Exclude lll issues for long lines with go:generate
+    - linters:
+        - lll
+      source: "^//go:generate "

--- a/go.mod
+++ b/go.mod
@@ -11,16 +11,14 @@ require (
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/hyperledger/fabric-protos-go v0.0.0-20190821180310-6b6ac9042dfd
-	github.com/hyperledger/fabric-sdk-go v1.0.0-alpha5.0.20190910134818-7c5b61c3218f
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta1
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.1
-	github.com/myitcv/gobin v0.0.10
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/prometheus/common v0.4.1 // indirect
 	github.com/prometheus/procfs v0.0.0-20190529155944-65bdadfa96ae // indirect
-	github.com/rogpeppe/go-internal v1.2.2 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1Q
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190821180310-6b6ac9042dfd h1:z0IbaMd4Ry2Cmmxujzy4UDgCUsT/0dOqqoGtOcvDw9Q=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190821180310-6b6ac9042dfd/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/hyperledger/fabric-sdk-go v1.0.0-alpha5.0.20190910134818-7c5b61c3218f h1:3aDdoY/JeY76rEFxqt44R00cD88myu6uZdVMkCos1cs=
-github.com/hyperledger/fabric-sdk-go v1.0.0-alpha5.0.20190910134818-7c5b61c3218f/go.mod h1:H5Atl/PpXhEKYYShSLFElohDoB11o4/R0OwBxOs7hcM=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta1 h1:id5BJE6TZu/SaGQahns6sO2o+n5fwps7GrWGCJJnAY8=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta1/go.mod h1:i8yJ9t8i1fGe7opUcq6uESxhruMJNXlc+Rx9ooBZsYg=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joefitzgerald/rainbow-reporter v0.1.0 h1:AuMG652zjdzI0YCCnXAqATtRBpGXMcAnrajcaTrSeuo=
@@ -108,8 +108,6 @@ github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/myitcv/gobin v0.0.10 h1:ZN7SQ6Qhc5UJ1e9CpYcbFNcE97GV1iCrzWFo3AuCJeI=
-github.com/myitcv/gobin v0.0.10/go.mod h1:ls+aW1M2tnZ+I/ANd/jBlqZpG6IY3Kbdq1q++Sb1Lak=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
@@ -148,9 +146,6 @@ github.com/prometheus/procfs v0.0.0-20190529155944-65bdadfa96ae h1:kF6Y/ES9NQmW3
 github.com/prometheus/procfs v0.0.0-20190529155944-65bdadfa96ae/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/go-internal v1.0.1-alpha.6/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.2.2 h1:J7U/N7eRtzjhs26d6GqMh2HBuXP8/Z64Densiiieafo=
-github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sclevine/spec v1.2.0 h1:1Jwdf9jSfDl9NVmt8ndHqbTZ7XCCPbh1jI3hkDBHVYA=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -259,8 +254,6 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/pkg/fabric/fabric_test.go
+++ b/pkg/fabric/fabric_test.go
@@ -22,7 +22,7 @@ import (
 //go:generate gobin -m -run github.com/maxbrunsfeld/counterfeiter/v6 -o mocks/ledger.go --fake-name Ledger . Ledger
 //go:generate gobin -m -run github.com/maxbrunsfeld/counterfeiter/v6 -o mocks/resmgmt.go --fake-name ResourceManagement . ResourceManagement
 //go:generate gobin -m -run github.com/maxbrunsfeld/counterfeiter/v6 -o mocks/msp.go --fake-name MSP . MSP
-//nolint:lll //go:generate gobin -m -run github.com/maxbrunsfeld/counterfeiter/v6 -o mocks/channelcfg.go --fake-name ChannelCfg github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab.ChannelCfg
+//go:generate gobin -m -run github.com/maxbrunsfeld/counterfeiter/v6 -o mocks/channelcfg.go --fake-name ChannelCfg github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab.ChannelCfg
 
 func TestFabric(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/fabric/mocks/channel.go
+++ b/pkg/fabric/mocks/channel.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Channel struct {
-	ExecuteStub        func(request channel.Request, options ...channel.RequestOption) (channel.Response, error)
+	ExecuteStub        func(channel.Request, ...channel.RequestOption) (channel.Response, error)
 	executeMutex       sync.RWMutex
 	executeArgsForCall []struct {
-		request channel.Request
-		options []channel.RequestOption
+		arg1 channel.Request
+		arg2 []channel.RequestOption
 	}
 	executeReturns struct {
 		result1 channel.Response
@@ -25,12 +25,12 @@ type Channel struct {
 		result1 channel.Response
 		result2 error
 	}
-	InvokeHandlerStub        func(handler invoke.Handler, request channel.Request, options ...channel.RequestOption) (channel.Response, error)
+	InvokeHandlerStub        func(invoke.Handler, channel.Request, ...channel.RequestOption) (channel.Response, error)
 	invokeHandlerMutex       sync.RWMutex
 	invokeHandlerArgsForCall []struct {
-		handler invoke.Handler
-		request channel.Request
-		options []channel.RequestOption
+		arg1 invoke.Handler
+		arg2 channel.Request
+		arg3 []channel.RequestOption
 	}
 	invokeHandlerReturns struct {
 		result1 channel.Response
@@ -40,11 +40,11 @@ type Channel struct {
 		result1 channel.Response
 		result2 error
 	}
-	QueryStub        func(request channel.Request, options ...channel.RequestOption) (channel.Response, error)
+	QueryStub        func(channel.Request, ...channel.RequestOption) (channel.Response, error)
 	queryMutex       sync.RWMutex
 	queryArgsForCall []struct {
-		request channel.Request
-		options []channel.RequestOption
+		arg1 channel.Request
+		arg2 []channel.RequestOption
 	}
 	queryReturns struct {
 		result1 channel.Response
@@ -54,11 +54,11 @@ type Channel struct {
 		result1 channel.Response
 		result2 error
 	}
-	RegisterChaincodeEventStub        func(chainCodeID string, eventFilter string) (fab.Registration, <-chan *fab.CCEvent, error)
+	RegisterChaincodeEventStub        func(string, string) (fab.Registration, <-chan *fab.CCEvent, error)
 	registerChaincodeEventMutex       sync.RWMutex
 	registerChaincodeEventArgsForCall []struct {
-		chainCodeID string
-		eventFilter string
+		arg1 string
+		arg2 string
 	}
 	registerChaincodeEventReturns struct {
 		result1 fab.Registration
@@ -70,31 +70,32 @@ type Channel struct {
 		result2 <-chan *fab.CCEvent
 		result3 error
 	}
-	UnregisterChaincodeEventStub        func(registration fab.Registration)
+	UnregisterChaincodeEventStub        func(fab.Registration)
 	unregisterChaincodeEventMutex       sync.RWMutex
 	unregisterChaincodeEventArgsForCall []struct {
-		registration fab.Registration
+		arg1 fab.Registration
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Channel) Execute(request channel.Request, options ...channel.RequestOption) (channel.Response, error) {
+func (fake *Channel) Execute(arg1 channel.Request, arg2 ...channel.RequestOption) (channel.Response, error) {
 	fake.executeMutex.Lock()
 	ret, specificReturn := fake.executeReturnsOnCall[len(fake.executeArgsForCall)]
 	fake.executeArgsForCall = append(fake.executeArgsForCall, struct {
-		request channel.Request
-		options []channel.RequestOption
-	}{request, options})
-	fake.recordInvocation("Execute", []interface{}{request, options})
+		arg1 channel.Request
+		arg2 []channel.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("Execute", []interface{}{arg1, arg2})
 	fake.executeMutex.Unlock()
 	if fake.ExecuteStub != nil {
-		return fake.ExecuteStub(request, options...)
+		return fake.ExecuteStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.executeReturns.result1, fake.executeReturns.result2
+	fakeReturns := fake.executeReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Channel) ExecuteCallCount() int {
@@ -103,13 +104,22 @@ func (fake *Channel) ExecuteCallCount() int {
 	return len(fake.executeArgsForCall)
 }
 
+func (fake *Channel) ExecuteCalls(stub func(channel.Request, ...channel.RequestOption) (channel.Response, error)) {
+	fake.executeMutex.Lock()
+	defer fake.executeMutex.Unlock()
+	fake.ExecuteStub = stub
+}
+
 func (fake *Channel) ExecuteArgsForCall(i int) (channel.Request, []channel.RequestOption) {
 	fake.executeMutex.RLock()
 	defer fake.executeMutex.RUnlock()
-	return fake.executeArgsForCall[i].request, fake.executeArgsForCall[i].options
+	argsForCall := fake.executeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Channel) ExecuteReturns(result1 channel.Response, result2 error) {
+	fake.executeMutex.Lock()
+	defer fake.executeMutex.Unlock()
 	fake.ExecuteStub = nil
 	fake.executeReturns = struct {
 		result1 channel.Response
@@ -118,6 +128,8 @@ func (fake *Channel) ExecuteReturns(result1 channel.Response, result2 error) {
 }
 
 func (fake *Channel) ExecuteReturnsOnCall(i int, result1 channel.Response, result2 error) {
+	fake.executeMutex.Lock()
+	defer fake.executeMutex.Unlock()
 	fake.ExecuteStub = nil
 	if fake.executeReturnsOnCall == nil {
 		fake.executeReturnsOnCall = make(map[int]struct {
@@ -131,23 +143,24 @@ func (fake *Channel) ExecuteReturnsOnCall(i int, result1 channel.Response, resul
 	}{result1, result2}
 }
 
-func (fake *Channel) InvokeHandler(handler invoke.Handler, request channel.Request, options ...channel.RequestOption) (channel.Response, error) {
+func (fake *Channel) InvokeHandler(arg1 invoke.Handler, arg2 channel.Request, arg3 ...channel.RequestOption) (channel.Response, error) {
 	fake.invokeHandlerMutex.Lock()
 	ret, specificReturn := fake.invokeHandlerReturnsOnCall[len(fake.invokeHandlerArgsForCall)]
 	fake.invokeHandlerArgsForCall = append(fake.invokeHandlerArgsForCall, struct {
-		handler invoke.Handler
-		request channel.Request
-		options []channel.RequestOption
-	}{handler, request, options})
-	fake.recordInvocation("InvokeHandler", []interface{}{handler, request, options})
+		arg1 invoke.Handler
+		arg2 channel.Request
+		arg3 []channel.RequestOption
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("InvokeHandler", []interface{}{arg1, arg2, arg3})
 	fake.invokeHandlerMutex.Unlock()
 	if fake.InvokeHandlerStub != nil {
-		return fake.InvokeHandlerStub(handler, request, options...)
+		return fake.InvokeHandlerStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.invokeHandlerReturns.result1, fake.invokeHandlerReturns.result2
+	fakeReturns := fake.invokeHandlerReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Channel) InvokeHandlerCallCount() int {
@@ -156,13 +169,22 @@ func (fake *Channel) InvokeHandlerCallCount() int {
 	return len(fake.invokeHandlerArgsForCall)
 }
 
+func (fake *Channel) InvokeHandlerCalls(stub func(invoke.Handler, channel.Request, ...channel.RequestOption) (channel.Response, error)) {
+	fake.invokeHandlerMutex.Lock()
+	defer fake.invokeHandlerMutex.Unlock()
+	fake.InvokeHandlerStub = stub
+}
+
 func (fake *Channel) InvokeHandlerArgsForCall(i int) (invoke.Handler, channel.Request, []channel.RequestOption) {
 	fake.invokeHandlerMutex.RLock()
 	defer fake.invokeHandlerMutex.RUnlock()
-	return fake.invokeHandlerArgsForCall[i].handler, fake.invokeHandlerArgsForCall[i].request, fake.invokeHandlerArgsForCall[i].options
+	argsForCall := fake.invokeHandlerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *Channel) InvokeHandlerReturns(result1 channel.Response, result2 error) {
+	fake.invokeHandlerMutex.Lock()
+	defer fake.invokeHandlerMutex.Unlock()
 	fake.InvokeHandlerStub = nil
 	fake.invokeHandlerReturns = struct {
 		result1 channel.Response
@@ -171,6 +193,8 @@ func (fake *Channel) InvokeHandlerReturns(result1 channel.Response, result2 erro
 }
 
 func (fake *Channel) InvokeHandlerReturnsOnCall(i int, result1 channel.Response, result2 error) {
+	fake.invokeHandlerMutex.Lock()
+	defer fake.invokeHandlerMutex.Unlock()
 	fake.InvokeHandlerStub = nil
 	if fake.invokeHandlerReturnsOnCall == nil {
 		fake.invokeHandlerReturnsOnCall = make(map[int]struct {
@@ -184,22 +208,23 @@ func (fake *Channel) InvokeHandlerReturnsOnCall(i int, result1 channel.Response,
 	}{result1, result2}
 }
 
-func (fake *Channel) Query(request channel.Request, options ...channel.RequestOption) (channel.Response, error) {
+func (fake *Channel) Query(arg1 channel.Request, arg2 ...channel.RequestOption) (channel.Response, error) {
 	fake.queryMutex.Lock()
 	ret, specificReturn := fake.queryReturnsOnCall[len(fake.queryArgsForCall)]
 	fake.queryArgsForCall = append(fake.queryArgsForCall, struct {
-		request channel.Request
-		options []channel.RequestOption
-	}{request, options})
-	fake.recordInvocation("Query", []interface{}{request, options})
+		arg1 channel.Request
+		arg2 []channel.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("Query", []interface{}{arg1, arg2})
 	fake.queryMutex.Unlock()
 	if fake.QueryStub != nil {
-		return fake.QueryStub(request, options...)
+		return fake.QueryStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryReturns.result1, fake.queryReturns.result2
+	fakeReturns := fake.queryReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Channel) QueryCallCount() int {
@@ -208,13 +233,22 @@ func (fake *Channel) QueryCallCount() int {
 	return len(fake.queryArgsForCall)
 }
 
+func (fake *Channel) QueryCalls(stub func(channel.Request, ...channel.RequestOption) (channel.Response, error)) {
+	fake.queryMutex.Lock()
+	defer fake.queryMutex.Unlock()
+	fake.QueryStub = stub
+}
+
 func (fake *Channel) QueryArgsForCall(i int) (channel.Request, []channel.RequestOption) {
 	fake.queryMutex.RLock()
 	defer fake.queryMutex.RUnlock()
-	return fake.queryArgsForCall[i].request, fake.queryArgsForCall[i].options
+	argsForCall := fake.queryArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Channel) QueryReturns(result1 channel.Response, result2 error) {
+	fake.queryMutex.Lock()
+	defer fake.queryMutex.Unlock()
 	fake.QueryStub = nil
 	fake.queryReturns = struct {
 		result1 channel.Response
@@ -223,6 +257,8 @@ func (fake *Channel) QueryReturns(result1 channel.Response, result2 error) {
 }
 
 func (fake *Channel) QueryReturnsOnCall(i int, result1 channel.Response, result2 error) {
+	fake.queryMutex.Lock()
+	defer fake.queryMutex.Unlock()
 	fake.QueryStub = nil
 	if fake.queryReturnsOnCall == nil {
 		fake.queryReturnsOnCall = make(map[int]struct {
@@ -236,22 +272,23 @@ func (fake *Channel) QueryReturnsOnCall(i int, result1 channel.Response, result2
 	}{result1, result2}
 }
 
-func (fake *Channel) RegisterChaincodeEvent(chainCodeID string, eventFilter string) (fab.Registration, <-chan *fab.CCEvent, error) {
+func (fake *Channel) RegisterChaincodeEvent(arg1 string, arg2 string) (fab.Registration, <-chan *fab.CCEvent, error) {
 	fake.registerChaincodeEventMutex.Lock()
 	ret, specificReturn := fake.registerChaincodeEventReturnsOnCall[len(fake.registerChaincodeEventArgsForCall)]
 	fake.registerChaincodeEventArgsForCall = append(fake.registerChaincodeEventArgsForCall, struct {
-		chainCodeID string
-		eventFilter string
-	}{chainCodeID, eventFilter})
-	fake.recordInvocation("RegisterChaincodeEvent", []interface{}{chainCodeID, eventFilter})
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("RegisterChaincodeEvent", []interface{}{arg1, arg2})
 	fake.registerChaincodeEventMutex.Unlock()
 	if fake.RegisterChaincodeEventStub != nil {
-		return fake.RegisterChaincodeEventStub(chainCodeID, eventFilter)
+		return fake.RegisterChaincodeEventStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.registerChaincodeEventReturns.result1, fake.registerChaincodeEventReturns.result2, fake.registerChaincodeEventReturns.result3
+	fakeReturns := fake.registerChaincodeEventReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Channel) RegisterChaincodeEventCallCount() int {
@@ -260,13 +297,22 @@ func (fake *Channel) RegisterChaincodeEventCallCount() int {
 	return len(fake.registerChaincodeEventArgsForCall)
 }
 
+func (fake *Channel) RegisterChaincodeEventCalls(stub func(string, string) (fab.Registration, <-chan *fab.CCEvent, error)) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
+	fake.RegisterChaincodeEventStub = stub
+}
+
 func (fake *Channel) RegisterChaincodeEventArgsForCall(i int) (string, string) {
 	fake.registerChaincodeEventMutex.RLock()
 	defer fake.registerChaincodeEventMutex.RUnlock()
-	return fake.registerChaincodeEventArgsForCall[i].chainCodeID, fake.registerChaincodeEventArgsForCall[i].eventFilter
+	argsForCall := fake.registerChaincodeEventArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Channel) RegisterChaincodeEventReturns(result1 fab.Registration, result2 <-chan *fab.CCEvent, result3 error) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
 	fake.RegisterChaincodeEventStub = nil
 	fake.registerChaincodeEventReturns = struct {
 		result1 fab.Registration
@@ -276,6 +322,8 @@ func (fake *Channel) RegisterChaincodeEventReturns(result1 fab.Registration, res
 }
 
 func (fake *Channel) RegisterChaincodeEventReturnsOnCall(i int, result1 fab.Registration, result2 <-chan *fab.CCEvent, result3 error) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
 	fake.RegisterChaincodeEventStub = nil
 	if fake.registerChaincodeEventReturnsOnCall == nil {
 		fake.registerChaincodeEventReturnsOnCall = make(map[int]struct {
@@ -291,15 +339,15 @@ func (fake *Channel) RegisterChaincodeEventReturnsOnCall(i int, result1 fab.Regi
 	}{result1, result2, result3}
 }
 
-func (fake *Channel) UnregisterChaincodeEvent(registration fab.Registration) {
+func (fake *Channel) UnregisterChaincodeEvent(arg1 fab.Registration) {
 	fake.unregisterChaincodeEventMutex.Lock()
 	fake.unregisterChaincodeEventArgsForCall = append(fake.unregisterChaincodeEventArgsForCall, struct {
-		registration fab.Registration
-	}{registration})
-	fake.recordInvocation("UnregisterChaincodeEvent", []interface{}{registration})
+		arg1 fab.Registration
+	}{arg1})
+	fake.recordInvocation("UnregisterChaincodeEvent", []interface{}{arg1})
 	fake.unregisterChaincodeEventMutex.Unlock()
 	if fake.UnregisterChaincodeEventStub != nil {
-		fake.UnregisterChaincodeEventStub(registration)
+		fake.UnregisterChaincodeEventStub(arg1)
 	}
 }
 
@@ -309,10 +357,17 @@ func (fake *Channel) UnregisterChaincodeEventCallCount() int {
 	return len(fake.unregisterChaincodeEventArgsForCall)
 }
 
+func (fake *Channel) UnregisterChaincodeEventCalls(stub func(fab.Registration)) {
+	fake.unregisterChaincodeEventMutex.Lock()
+	defer fake.unregisterChaincodeEventMutex.Unlock()
+	fake.UnregisterChaincodeEventStub = stub
+}
+
 func (fake *Channel) UnregisterChaincodeEventArgsForCall(i int) fab.Registration {
 	fake.unregisterChaincodeEventMutex.RLock()
 	defer fake.unregisterChaincodeEventMutex.RUnlock()
-	return fake.unregisterChaincodeEventArgsForCall[i].registration
+	argsForCall := fake.unregisterChaincodeEventArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Channel) Invocations() map[string][][]interface{} {

--- a/pkg/fabric/mocks/channelcfg.go
+++ b/pkg/fabric/mocks/channelcfg.go
@@ -4,70 +4,36 @@ package mocks
 import (
 	"sync"
 
-	mspCfg "github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
 type ChannelCfg struct {
-	IDStub        func() string
-	iDMutex       sync.RWMutex
-	iDArgsForCall []struct{}
-	iDReturns     struct {
-		result1 string
-	}
-	iDReturnsOnCall map[int]struct {
-		result1 string
-	}
-	BlockNumberStub        func() uint64
-	blockNumberMutex       sync.RWMutex
-	blockNumberArgsForCall []struct{}
-	blockNumberReturns     struct {
-		result1 uint64
-	}
-	blockNumberReturnsOnCall map[int]struct {
-		result1 uint64
-	}
-	MSPsStub        func() []*mspCfg.MSPConfig
-	mSPsMutex       sync.RWMutex
-	mSPsArgsForCall []struct{}
-	mSPsReturns     struct {
-		result1 []*mspCfg.MSPConfig
-	}
-	mSPsReturnsOnCall map[int]struct {
-		result1 []*mspCfg.MSPConfig
-	}
 	AnchorPeersStub        func() []*fab.OrgAnchorPeer
 	anchorPeersMutex       sync.RWMutex
-	anchorPeersArgsForCall []struct{}
-	anchorPeersReturns     struct {
+	anchorPeersArgsForCall []struct {
+	}
+	anchorPeersReturns struct {
 		result1 []*fab.OrgAnchorPeer
 	}
 	anchorPeersReturnsOnCall map[int]struct {
 		result1 []*fab.OrgAnchorPeer
 	}
-	OrderersStub        func() []string
-	orderersMutex       sync.RWMutex
-	orderersArgsForCall []struct{}
-	orderersReturns     struct {
-		result1 []string
+	BlockNumberStub        func() uint64
+	blockNumberMutex       sync.RWMutex
+	blockNumberArgsForCall []struct {
 	}
-	orderersReturnsOnCall map[int]struct {
-		result1 []string
+	blockNumberReturns struct {
+		result1 uint64
 	}
-	VersionsStub        func() *fab.Versions
-	versionsMutex       sync.RWMutex
-	versionsArgsForCall []struct{}
-	versionsReturns     struct {
-		result1 *fab.Versions
+	blockNumberReturnsOnCall map[int]struct {
+		result1 uint64
 	}
-	versionsReturnsOnCall map[int]struct {
-		result1 *fab.Versions
-	}
-	HasCapabilityStub        func(group fab.ConfigGroupKey, capability string) bool
+	HasCapabilityStub        func(fab.ConfigGroupKey, string) bool
 	hasCapabilityMutex       sync.RWMutex
 	hasCapabilityArgsForCall []struct {
-		group      fab.ConfigGroupKey
-		capability string
+		arg1 fab.ConfigGroupKey
+		arg2 string
 	}
 	hasCapabilityReturns struct {
 		result1 bool
@@ -75,134 +41,55 @@ type ChannelCfg struct {
 	hasCapabilityReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	IDStub        func() string
+	iDMutex       sync.RWMutex
+	iDArgsForCall []struct {
+	}
+	iDReturns struct {
+		result1 string
+	}
+	iDReturnsOnCall map[int]struct {
+		result1 string
+	}
+	MSPsStub        func() []*msp.MSPConfig
+	mSPsMutex       sync.RWMutex
+	mSPsArgsForCall []struct {
+	}
+	mSPsReturns struct {
+		result1 []*msp.MSPConfig
+	}
+	mSPsReturnsOnCall map[int]struct {
+		result1 []*msp.MSPConfig
+	}
+	OrderersStub        func() []string
+	orderersMutex       sync.RWMutex
+	orderersArgsForCall []struct {
+	}
+	orderersReturns struct {
+		result1 []string
+	}
+	orderersReturnsOnCall map[int]struct {
+		result1 []string
+	}
+	VersionsStub        func() *fab.Versions
+	versionsMutex       sync.RWMutex
+	versionsArgsForCall []struct {
+	}
+	versionsReturns struct {
+		result1 *fab.Versions
+	}
+	versionsReturnsOnCall map[int]struct {
+		result1 *fab.Versions
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *ChannelCfg) ID() string {
-	fake.iDMutex.Lock()
-	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
-	fake.iDArgsForCall = append(fake.iDArgsForCall, struct{}{})
-	fake.recordInvocation("ID", []interface{}{})
-	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.iDReturns.result1
-}
-
-func (fake *ChannelCfg) IDCallCount() int {
-	fake.iDMutex.RLock()
-	defer fake.iDMutex.RUnlock()
-	return len(fake.iDArgsForCall)
-}
-
-func (fake *ChannelCfg) IDReturns(result1 string) {
-	fake.IDStub = nil
-	fake.iDReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *ChannelCfg) IDReturnsOnCall(i int, result1 string) {
-	fake.IDStub = nil
-	if fake.iDReturnsOnCall == nil {
-		fake.iDReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.iDReturnsOnCall[i] = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *ChannelCfg) BlockNumber() uint64 {
-	fake.blockNumberMutex.Lock()
-	ret, specificReturn := fake.blockNumberReturnsOnCall[len(fake.blockNumberArgsForCall)]
-	fake.blockNumberArgsForCall = append(fake.blockNumberArgsForCall, struct{}{})
-	fake.recordInvocation("BlockNumber", []interface{}{})
-	fake.blockNumberMutex.Unlock()
-	if fake.BlockNumberStub != nil {
-		return fake.BlockNumberStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.blockNumberReturns.result1
-}
-
-func (fake *ChannelCfg) BlockNumberCallCount() int {
-	fake.blockNumberMutex.RLock()
-	defer fake.blockNumberMutex.RUnlock()
-	return len(fake.blockNumberArgsForCall)
-}
-
-func (fake *ChannelCfg) BlockNumberReturns(result1 uint64) {
-	fake.BlockNumberStub = nil
-	fake.blockNumberReturns = struct {
-		result1 uint64
-	}{result1}
-}
-
-func (fake *ChannelCfg) BlockNumberReturnsOnCall(i int, result1 uint64) {
-	fake.BlockNumberStub = nil
-	if fake.blockNumberReturnsOnCall == nil {
-		fake.blockNumberReturnsOnCall = make(map[int]struct {
-			result1 uint64
-		})
-	}
-	fake.blockNumberReturnsOnCall[i] = struct {
-		result1 uint64
-	}{result1}
-}
-
-func (fake *ChannelCfg) MSPs() []*mspCfg.MSPConfig {
-	fake.mSPsMutex.Lock()
-	ret, specificReturn := fake.mSPsReturnsOnCall[len(fake.mSPsArgsForCall)]
-	fake.mSPsArgsForCall = append(fake.mSPsArgsForCall, struct{}{})
-	fake.recordInvocation("MSPs", []interface{}{})
-	fake.mSPsMutex.Unlock()
-	if fake.MSPsStub != nil {
-		return fake.MSPsStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.mSPsReturns.result1
-}
-
-func (fake *ChannelCfg) MSPsCallCount() int {
-	fake.mSPsMutex.RLock()
-	defer fake.mSPsMutex.RUnlock()
-	return len(fake.mSPsArgsForCall)
-}
-
-func (fake *ChannelCfg) MSPsReturns(result1 []*mspCfg.MSPConfig) {
-	fake.MSPsStub = nil
-	fake.mSPsReturns = struct {
-		result1 []*mspCfg.MSPConfig
-	}{result1}
-}
-
-func (fake *ChannelCfg) MSPsReturnsOnCall(i int, result1 []*mspCfg.MSPConfig) {
-	fake.MSPsStub = nil
-	if fake.mSPsReturnsOnCall == nil {
-		fake.mSPsReturnsOnCall = make(map[int]struct {
-			result1 []*mspCfg.MSPConfig
-		})
-	}
-	fake.mSPsReturnsOnCall[i] = struct {
-		result1 []*mspCfg.MSPConfig
-	}{result1}
 }
 
 func (fake *ChannelCfg) AnchorPeers() []*fab.OrgAnchorPeer {
 	fake.anchorPeersMutex.Lock()
 	ret, specificReturn := fake.anchorPeersReturnsOnCall[len(fake.anchorPeersArgsForCall)]
-	fake.anchorPeersArgsForCall = append(fake.anchorPeersArgsForCall, struct{}{})
+	fake.anchorPeersArgsForCall = append(fake.anchorPeersArgsForCall, struct {
+	}{})
 	fake.recordInvocation("AnchorPeers", []interface{}{})
 	fake.anchorPeersMutex.Unlock()
 	if fake.AnchorPeersStub != nil {
@@ -211,7 +98,8 @@ func (fake *ChannelCfg) AnchorPeers() []*fab.OrgAnchorPeer {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.anchorPeersReturns.result1
+	fakeReturns := fake.anchorPeersReturns
+	return fakeReturns.result1
 }
 
 func (fake *ChannelCfg) AnchorPeersCallCount() int {
@@ -220,7 +108,15 @@ func (fake *ChannelCfg) AnchorPeersCallCount() int {
 	return len(fake.anchorPeersArgsForCall)
 }
 
+func (fake *ChannelCfg) AnchorPeersCalls(stub func() []*fab.OrgAnchorPeer) {
+	fake.anchorPeersMutex.Lock()
+	defer fake.anchorPeersMutex.Unlock()
+	fake.AnchorPeersStub = stub
+}
+
 func (fake *ChannelCfg) AnchorPeersReturns(result1 []*fab.OrgAnchorPeer) {
+	fake.anchorPeersMutex.Lock()
+	defer fake.anchorPeersMutex.Unlock()
 	fake.AnchorPeersStub = nil
 	fake.anchorPeersReturns = struct {
 		result1 []*fab.OrgAnchorPeer
@@ -228,6 +124,8 @@ func (fake *ChannelCfg) AnchorPeersReturns(result1 []*fab.OrgAnchorPeer) {
 }
 
 func (fake *ChannelCfg) AnchorPeersReturnsOnCall(i int, result1 []*fab.OrgAnchorPeer) {
+	fake.anchorPeersMutex.Lock()
+	defer fake.anchorPeersMutex.Unlock()
 	fake.AnchorPeersStub = nil
 	if fake.anchorPeersReturnsOnCall == nil {
 		fake.anchorPeersReturnsOnCall = make(map[int]struct {
@@ -239,10 +137,228 @@ func (fake *ChannelCfg) AnchorPeersReturnsOnCall(i int, result1 []*fab.OrgAnchor
 	}{result1}
 }
 
+func (fake *ChannelCfg) BlockNumber() uint64 {
+	fake.blockNumberMutex.Lock()
+	ret, specificReturn := fake.blockNumberReturnsOnCall[len(fake.blockNumberArgsForCall)]
+	fake.blockNumberArgsForCall = append(fake.blockNumberArgsForCall, struct {
+	}{})
+	fake.recordInvocation("BlockNumber", []interface{}{})
+	fake.blockNumberMutex.Unlock()
+	if fake.BlockNumberStub != nil {
+		return fake.BlockNumberStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.blockNumberReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelCfg) BlockNumberCallCount() int {
+	fake.blockNumberMutex.RLock()
+	defer fake.blockNumberMutex.RUnlock()
+	return len(fake.blockNumberArgsForCall)
+}
+
+func (fake *ChannelCfg) BlockNumberCalls(stub func() uint64) {
+	fake.blockNumberMutex.Lock()
+	defer fake.blockNumberMutex.Unlock()
+	fake.BlockNumberStub = stub
+}
+
+func (fake *ChannelCfg) BlockNumberReturns(result1 uint64) {
+	fake.blockNumberMutex.Lock()
+	defer fake.blockNumberMutex.Unlock()
+	fake.BlockNumberStub = nil
+	fake.blockNumberReturns = struct {
+		result1 uint64
+	}{result1}
+}
+
+func (fake *ChannelCfg) BlockNumberReturnsOnCall(i int, result1 uint64) {
+	fake.blockNumberMutex.Lock()
+	defer fake.blockNumberMutex.Unlock()
+	fake.BlockNumberStub = nil
+	if fake.blockNumberReturnsOnCall == nil {
+		fake.blockNumberReturnsOnCall = make(map[int]struct {
+			result1 uint64
+		})
+	}
+	fake.blockNumberReturnsOnCall[i] = struct {
+		result1 uint64
+	}{result1}
+}
+
+func (fake *ChannelCfg) HasCapability(arg1 fab.ConfigGroupKey, arg2 string) bool {
+	fake.hasCapabilityMutex.Lock()
+	ret, specificReturn := fake.hasCapabilityReturnsOnCall[len(fake.hasCapabilityArgsForCall)]
+	fake.hasCapabilityArgsForCall = append(fake.hasCapabilityArgsForCall, struct {
+		arg1 fab.ConfigGroupKey
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("HasCapability", []interface{}{arg1, arg2})
+	fake.hasCapabilityMutex.Unlock()
+	if fake.HasCapabilityStub != nil {
+		return fake.HasCapabilityStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.hasCapabilityReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelCfg) HasCapabilityCallCount() int {
+	fake.hasCapabilityMutex.RLock()
+	defer fake.hasCapabilityMutex.RUnlock()
+	return len(fake.hasCapabilityArgsForCall)
+}
+
+func (fake *ChannelCfg) HasCapabilityCalls(stub func(fab.ConfigGroupKey, string) bool) {
+	fake.hasCapabilityMutex.Lock()
+	defer fake.hasCapabilityMutex.Unlock()
+	fake.HasCapabilityStub = stub
+}
+
+func (fake *ChannelCfg) HasCapabilityArgsForCall(i int) (fab.ConfigGroupKey, string) {
+	fake.hasCapabilityMutex.RLock()
+	defer fake.hasCapabilityMutex.RUnlock()
+	argsForCall := fake.hasCapabilityArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ChannelCfg) HasCapabilityReturns(result1 bool) {
+	fake.hasCapabilityMutex.Lock()
+	defer fake.hasCapabilityMutex.Unlock()
+	fake.HasCapabilityStub = nil
+	fake.hasCapabilityReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *ChannelCfg) HasCapabilityReturnsOnCall(i int, result1 bool) {
+	fake.hasCapabilityMutex.Lock()
+	defer fake.hasCapabilityMutex.Unlock()
+	fake.HasCapabilityStub = nil
+	if fake.hasCapabilityReturnsOnCall == nil {
+		fake.hasCapabilityReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.hasCapabilityReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *ChannelCfg) ID() string {
+	fake.iDMutex.Lock()
+	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
+	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ID", []interface{}{})
+	fake.iDMutex.Unlock()
+	if fake.IDStub != nil {
+		return fake.IDStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.iDReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelCfg) IDCallCount() int {
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
+	return len(fake.iDArgsForCall)
+}
+
+func (fake *ChannelCfg) IDCalls(stub func() string) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = stub
+}
+
+func (fake *ChannelCfg) IDReturns(result1 string) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	fake.iDReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *ChannelCfg) IDReturnsOnCall(i int, result1 string) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	if fake.iDReturnsOnCall == nil {
+		fake.iDReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.iDReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *ChannelCfg) MSPs() []*msp.MSPConfig {
+	fake.mSPsMutex.Lock()
+	ret, specificReturn := fake.mSPsReturnsOnCall[len(fake.mSPsArgsForCall)]
+	fake.mSPsArgsForCall = append(fake.mSPsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("MSPs", []interface{}{})
+	fake.mSPsMutex.Unlock()
+	if fake.MSPsStub != nil {
+		return fake.MSPsStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.mSPsReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelCfg) MSPsCallCount() int {
+	fake.mSPsMutex.RLock()
+	defer fake.mSPsMutex.RUnlock()
+	return len(fake.mSPsArgsForCall)
+}
+
+func (fake *ChannelCfg) MSPsCalls(stub func() []*msp.MSPConfig) {
+	fake.mSPsMutex.Lock()
+	defer fake.mSPsMutex.Unlock()
+	fake.MSPsStub = stub
+}
+
+func (fake *ChannelCfg) MSPsReturns(result1 []*msp.MSPConfig) {
+	fake.mSPsMutex.Lock()
+	defer fake.mSPsMutex.Unlock()
+	fake.MSPsStub = nil
+	fake.mSPsReturns = struct {
+		result1 []*msp.MSPConfig
+	}{result1}
+}
+
+func (fake *ChannelCfg) MSPsReturnsOnCall(i int, result1 []*msp.MSPConfig) {
+	fake.mSPsMutex.Lock()
+	defer fake.mSPsMutex.Unlock()
+	fake.MSPsStub = nil
+	if fake.mSPsReturnsOnCall == nil {
+		fake.mSPsReturnsOnCall = make(map[int]struct {
+			result1 []*msp.MSPConfig
+		})
+	}
+	fake.mSPsReturnsOnCall[i] = struct {
+		result1 []*msp.MSPConfig
+	}{result1}
+}
+
 func (fake *ChannelCfg) Orderers() []string {
 	fake.orderersMutex.Lock()
 	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
-	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct{}{})
+	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Orderers", []interface{}{})
 	fake.orderersMutex.Unlock()
 	if fake.OrderersStub != nil {
@@ -251,7 +367,8 @@ func (fake *ChannelCfg) Orderers() []string {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.orderersReturns.result1
+	fakeReturns := fake.orderersReturns
+	return fakeReturns.result1
 }
 
 func (fake *ChannelCfg) OrderersCallCount() int {
@@ -260,7 +377,15 @@ func (fake *ChannelCfg) OrderersCallCount() int {
 	return len(fake.orderersArgsForCall)
 }
 
+func (fake *ChannelCfg) OrderersCalls(stub func() []string) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = stub
+}
+
 func (fake *ChannelCfg) OrderersReturns(result1 []string) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
 	fake.OrderersStub = nil
 	fake.orderersReturns = struct {
 		result1 []string
@@ -268,6 +393,8 @@ func (fake *ChannelCfg) OrderersReturns(result1 []string) {
 }
 
 func (fake *ChannelCfg) OrderersReturnsOnCall(i int, result1 []string) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
 	fake.OrderersStub = nil
 	if fake.orderersReturnsOnCall == nil {
 		fake.orderersReturnsOnCall = make(map[int]struct {
@@ -282,7 +409,8 @@ func (fake *ChannelCfg) OrderersReturnsOnCall(i int, result1 []string) {
 func (fake *ChannelCfg) Versions() *fab.Versions {
 	fake.versionsMutex.Lock()
 	ret, specificReturn := fake.versionsReturnsOnCall[len(fake.versionsArgsForCall)]
-	fake.versionsArgsForCall = append(fake.versionsArgsForCall, struct{}{})
+	fake.versionsArgsForCall = append(fake.versionsArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Versions", []interface{}{})
 	fake.versionsMutex.Unlock()
 	if fake.VersionsStub != nil {
@@ -291,7 +419,8 @@ func (fake *ChannelCfg) Versions() *fab.Versions {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.versionsReturns.result1
+	fakeReturns := fake.versionsReturns
+	return fakeReturns.result1
 }
 
 func (fake *ChannelCfg) VersionsCallCount() int {
@@ -300,7 +429,15 @@ func (fake *ChannelCfg) VersionsCallCount() int {
 	return len(fake.versionsArgsForCall)
 }
 
+func (fake *ChannelCfg) VersionsCalls(stub func() *fab.Versions) {
+	fake.versionsMutex.Lock()
+	defer fake.versionsMutex.Unlock()
+	fake.VersionsStub = stub
+}
+
 func (fake *ChannelCfg) VersionsReturns(result1 *fab.Versions) {
+	fake.versionsMutex.Lock()
+	defer fake.versionsMutex.Unlock()
 	fake.VersionsStub = nil
 	fake.versionsReturns = struct {
 		result1 *fab.Versions
@@ -308,6 +445,8 @@ func (fake *ChannelCfg) VersionsReturns(result1 *fab.Versions) {
 }
 
 func (fake *ChannelCfg) VersionsReturnsOnCall(i int, result1 *fab.Versions) {
+	fake.versionsMutex.Lock()
+	defer fake.versionsMutex.Unlock()
 	fake.VersionsStub = nil
 	if fake.versionsReturnsOnCall == nil {
 		fake.versionsReturnsOnCall = make(map[int]struct {
@@ -319,72 +458,23 @@ func (fake *ChannelCfg) VersionsReturnsOnCall(i int, result1 *fab.Versions) {
 	}{result1}
 }
 
-func (fake *ChannelCfg) HasCapability(group fab.ConfigGroupKey, capability string) bool {
-	fake.hasCapabilityMutex.Lock()
-	ret, specificReturn := fake.hasCapabilityReturnsOnCall[len(fake.hasCapabilityArgsForCall)]
-	fake.hasCapabilityArgsForCall = append(fake.hasCapabilityArgsForCall, struct {
-		group      fab.ConfigGroupKey
-		capability string
-	}{group, capability})
-	fake.recordInvocation("HasCapability", []interface{}{group, capability})
-	fake.hasCapabilityMutex.Unlock()
-	if fake.HasCapabilityStub != nil {
-		return fake.HasCapabilityStub(group, capability)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.hasCapabilityReturns.result1
-}
-
-func (fake *ChannelCfg) HasCapabilityCallCount() int {
-	fake.hasCapabilityMutex.RLock()
-	defer fake.hasCapabilityMutex.RUnlock()
-	return len(fake.hasCapabilityArgsForCall)
-}
-
-func (fake *ChannelCfg) HasCapabilityArgsForCall(i int) (fab.ConfigGroupKey, string) {
-	fake.hasCapabilityMutex.RLock()
-	defer fake.hasCapabilityMutex.RUnlock()
-	return fake.hasCapabilityArgsForCall[i].group, fake.hasCapabilityArgsForCall[i].capability
-}
-
-func (fake *ChannelCfg) HasCapabilityReturns(result1 bool) {
-	fake.HasCapabilityStub = nil
-	fake.hasCapabilityReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *ChannelCfg) HasCapabilityReturnsOnCall(i int, result1 bool) {
-	fake.HasCapabilityStub = nil
-	if fake.hasCapabilityReturnsOnCall == nil {
-		fake.hasCapabilityReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.hasCapabilityReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *ChannelCfg) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.iDMutex.RLock()
-	defer fake.iDMutex.RUnlock()
-	fake.blockNumberMutex.RLock()
-	defer fake.blockNumberMutex.RUnlock()
-	fake.mSPsMutex.RLock()
-	defer fake.mSPsMutex.RUnlock()
 	fake.anchorPeersMutex.RLock()
 	defer fake.anchorPeersMutex.RUnlock()
+	fake.blockNumberMutex.RLock()
+	defer fake.blockNumberMutex.RUnlock()
+	fake.hasCapabilityMutex.RLock()
+	defer fake.hasCapabilityMutex.RUnlock()
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
+	fake.mSPsMutex.RLock()
+	defer fake.mSPsMutex.RUnlock()
 	fake.orderersMutex.RLock()
 	defer fake.orderersMutex.RUnlock()
 	fake.versionsMutex.RLock()
 	defer fake.versionsMutex.RUnlock()
-	fake.hasCapabilityMutex.RLock()
-	defer fake.hasCapabilityMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/fabric/mocks/event.go
+++ b/pkg/fabric/mocks/event.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Event struct {
-	RegisterBlockEventStub        func(filter ...fab.BlockFilter) (fab.Registration, <-chan *fab.BlockEvent, error)
+	RegisterBlockEventStub        func(...fab.BlockFilter) (fab.Registration, <-chan *fab.BlockEvent, error)
 	registerBlockEventMutex       sync.RWMutex
 	registerBlockEventArgsForCall []struct {
-		filter []fab.BlockFilter
+		arg1 []fab.BlockFilter
 	}
 	registerBlockEventReturns struct {
 		result1 fab.Registration
@@ -24,11 +24,11 @@ type Event struct {
 		result2 <-chan *fab.BlockEvent
 		result3 error
 	}
-	RegisterChaincodeEventStub        func(ccID, eventFilter string) (fab.Registration, <-chan *fab.CCEvent, error)
+	RegisterChaincodeEventStub        func(string, string) (fab.Registration, <-chan *fab.CCEvent, error)
 	registerChaincodeEventMutex       sync.RWMutex
 	registerChaincodeEventArgsForCall []struct {
-		ccID        string
-		eventFilter string
+		arg1 string
+		arg2 string
 	}
 	registerChaincodeEventReturns struct {
 		result1 fab.Registration
@@ -42,8 +42,9 @@ type Event struct {
 	}
 	RegisterFilteredBlockEventStub        func() (fab.Registration, <-chan *fab.FilteredBlockEvent, error)
 	registerFilteredBlockEventMutex       sync.RWMutex
-	registerFilteredBlockEventArgsForCall []struct{}
-	registerFilteredBlockEventReturns     struct {
+	registerFilteredBlockEventArgsForCall []struct {
+	}
+	registerFilteredBlockEventReturns struct {
 		result1 fab.Registration
 		result2 <-chan *fab.FilteredBlockEvent
 		result3 error
@@ -53,10 +54,10 @@ type Event struct {
 		result2 <-chan *fab.FilteredBlockEvent
 		result3 error
 	}
-	RegisterTxStatusEventStub        func(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error)
+	RegisterTxStatusEventStub        func(string) (fab.Registration, <-chan *fab.TxStatusEvent, error)
 	registerTxStatusEventMutex       sync.RWMutex
 	registerTxStatusEventArgsForCall []struct {
-		txID string
+		arg1 string
 	}
 	registerTxStatusEventReturns struct {
 		result1 fab.Registration
@@ -68,30 +69,31 @@ type Event struct {
 		result2 <-chan *fab.TxStatusEvent
 		result3 error
 	}
-	UnregisterStub        func(reg fab.Registration)
+	UnregisterStub        func(fab.Registration)
 	unregisterMutex       sync.RWMutex
 	unregisterArgsForCall []struct {
-		reg fab.Registration
+		arg1 fab.Registration
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Event) RegisterBlockEvent(filter ...fab.BlockFilter) (fab.Registration, <-chan *fab.BlockEvent, error) {
+func (fake *Event) RegisterBlockEvent(arg1 ...fab.BlockFilter) (fab.Registration, <-chan *fab.BlockEvent, error) {
 	fake.registerBlockEventMutex.Lock()
 	ret, specificReturn := fake.registerBlockEventReturnsOnCall[len(fake.registerBlockEventArgsForCall)]
 	fake.registerBlockEventArgsForCall = append(fake.registerBlockEventArgsForCall, struct {
-		filter []fab.BlockFilter
-	}{filter})
-	fake.recordInvocation("RegisterBlockEvent", []interface{}{filter})
+		arg1 []fab.BlockFilter
+	}{arg1})
+	fake.recordInvocation("RegisterBlockEvent", []interface{}{arg1})
 	fake.registerBlockEventMutex.Unlock()
 	if fake.RegisterBlockEventStub != nil {
-		return fake.RegisterBlockEventStub(filter...)
+		return fake.RegisterBlockEventStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.registerBlockEventReturns.result1, fake.registerBlockEventReturns.result2, fake.registerBlockEventReturns.result3
+	fakeReturns := fake.registerBlockEventReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Event) RegisterBlockEventCallCount() int {
@@ -100,13 +102,22 @@ func (fake *Event) RegisterBlockEventCallCount() int {
 	return len(fake.registerBlockEventArgsForCall)
 }
 
+func (fake *Event) RegisterBlockEventCalls(stub func(...fab.BlockFilter) (fab.Registration, <-chan *fab.BlockEvent, error)) {
+	fake.registerBlockEventMutex.Lock()
+	defer fake.registerBlockEventMutex.Unlock()
+	fake.RegisterBlockEventStub = stub
+}
+
 func (fake *Event) RegisterBlockEventArgsForCall(i int) []fab.BlockFilter {
 	fake.registerBlockEventMutex.RLock()
 	defer fake.registerBlockEventMutex.RUnlock()
-	return fake.registerBlockEventArgsForCall[i].filter
+	argsForCall := fake.registerBlockEventArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Event) RegisterBlockEventReturns(result1 fab.Registration, result2 <-chan *fab.BlockEvent, result3 error) {
+	fake.registerBlockEventMutex.Lock()
+	defer fake.registerBlockEventMutex.Unlock()
 	fake.RegisterBlockEventStub = nil
 	fake.registerBlockEventReturns = struct {
 		result1 fab.Registration
@@ -116,6 +127,8 @@ func (fake *Event) RegisterBlockEventReturns(result1 fab.Registration, result2 <
 }
 
 func (fake *Event) RegisterBlockEventReturnsOnCall(i int, result1 fab.Registration, result2 <-chan *fab.BlockEvent, result3 error) {
+	fake.registerBlockEventMutex.Lock()
+	defer fake.registerBlockEventMutex.Unlock()
 	fake.RegisterBlockEventStub = nil
 	if fake.registerBlockEventReturnsOnCall == nil {
 		fake.registerBlockEventReturnsOnCall = make(map[int]struct {
@@ -131,22 +144,23 @@ func (fake *Event) RegisterBlockEventReturnsOnCall(i int, result1 fab.Registrati
 	}{result1, result2, result3}
 }
 
-func (fake *Event) RegisterChaincodeEvent(ccID string, eventFilter string) (fab.Registration, <-chan *fab.CCEvent, error) {
+func (fake *Event) RegisterChaincodeEvent(arg1 string, arg2 string) (fab.Registration, <-chan *fab.CCEvent, error) {
 	fake.registerChaincodeEventMutex.Lock()
 	ret, specificReturn := fake.registerChaincodeEventReturnsOnCall[len(fake.registerChaincodeEventArgsForCall)]
 	fake.registerChaincodeEventArgsForCall = append(fake.registerChaincodeEventArgsForCall, struct {
-		ccID        string
-		eventFilter string
-	}{ccID, eventFilter})
-	fake.recordInvocation("RegisterChaincodeEvent", []interface{}{ccID, eventFilter})
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("RegisterChaincodeEvent", []interface{}{arg1, arg2})
 	fake.registerChaincodeEventMutex.Unlock()
 	if fake.RegisterChaincodeEventStub != nil {
-		return fake.RegisterChaincodeEventStub(ccID, eventFilter)
+		return fake.RegisterChaincodeEventStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.registerChaincodeEventReturns.result1, fake.registerChaincodeEventReturns.result2, fake.registerChaincodeEventReturns.result3
+	fakeReturns := fake.registerChaincodeEventReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Event) RegisterChaincodeEventCallCount() int {
@@ -155,13 +169,22 @@ func (fake *Event) RegisterChaincodeEventCallCount() int {
 	return len(fake.registerChaincodeEventArgsForCall)
 }
 
+func (fake *Event) RegisterChaincodeEventCalls(stub func(string, string) (fab.Registration, <-chan *fab.CCEvent, error)) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
+	fake.RegisterChaincodeEventStub = stub
+}
+
 func (fake *Event) RegisterChaincodeEventArgsForCall(i int) (string, string) {
 	fake.registerChaincodeEventMutex.RLock()
 	defer fake.registerChaincodeEventMutex.RUnlock()
-	return fake.registerChaincodeEventArgsForCall[i].ccID, fake.registerChaincodeEventArgsForCall[i].eventFilter
+	argsForCall := fake.registerChaincodeEventArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Event) RegisterChaincodeEventReturns(result1 fab.Registration, result2 <-chan *fab.CCEvent, result3 error) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
 	fake.RegisterChaincodeEventStub = nil
 	fake.registerChaincodeEventReturns = struct {
 		result1 fab.Registration
@@ -171,6 +194,8 @@ func (fake *Event) RegisterChaincodeEventReturns(result1 fab.Registration, resul
 }
 
 func (fake *Event) RegisterChaincodeEventReturnsOnCall(i int, result1 fab.Registration, result2 <-chan *fab.CCEvent, result3 error) {
+	fake.registerChaincodeEventMutex.Lock()
+	defer fake.registerChaincodeEventMutex.Unlock()
 	fake.RegisterChaincodeEventStub = nil
 	if fake.registerChaincodeEventReturnsOnCall == nil {
 		fake.registerChaincodeEventReturnsOnCall = make(map[int]struct {
@@ -189,7 +214,8 @@ func (fake *Event) RegisterChaincodeEventReturnsOnCall(i int, result1 fab.Regist
 func (fake *Event) RegisterFilteredBlockEvent() (fab.Registration, <-chan *fab.FilteredBlockEvent, error) {
 	fake.registerFilteredBlockEventMutex.Lock()
 	ret, specificReturn := fake.registerFilteredBlockEventReturnsOnCall[len(fake.registerFilteredBlockEventArgsForCall)]
-	fake.registerFilteredBlockEventArgsForCall = append(fake.registerFilteredBlockEventArgsForCall, struct{}{})
+	fake.registerFilteredBlockEventArgsForCall = append(fake.registerFilteredBlockEventArgsForCall, struct {
+	}{})
 	fake.recordInvocation("RegisterFilteredBlockEvent", []interface{}{})
 	fake.registerFilteredBlockEventMutex.Unlock()
 	if fake.RegisterFilteredBlockEventStub != nil {
@@ -198,7 +224,8 @@ func (fake *Event) RegisterFilteredBlockEvent() (fab.Registration, <-chan *fab.F
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.registerFilteredBlockEventReturns.result1, fake.registerFilteredBlockEventReturns.result2, fake.registerFilteredBlockEventReturns.result3
+	fakeReturns := fake.registerFilteredBlockEventReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Event) RegisterFilteredBlockEventCallCount() int {
@@ -207,7 +234,15 @@ func (fake *Event) RegisterFilteredBlockEventCallCount() int {
 	return len(fake.registerFilteredBlockEventArgsForCall)
 }
 
+func (fake *Event) RegisterFilteredBlockEventCalls(stub func() (fab.Registration, <-chan *fab.FilteredBlockEvent, error)) {
+	fake.registerFilteredBlockEventMutex.Lock()
+	defer fake.registerFilteredBlockEventMutex.Unlock()
+	fake.RegisterFilteredBlockEventStub = stub
+}
+
 func (fake *Event) RegisterFilteredBlockEventReturns(result1 fab.Registration, result2 <-chan *fab.FilteredBlockEvent, result3 error) {
+	fake.registerFilteredBlockEventMutex.Lock()
+	defer fake.registerFilteredBlockEventMutex.Unlock()
 	fake.RegisterFilteredBlockEventStub = nil
 	fake.registerFilteredBlockEventReturns = struct {
 		result1 fab.Registration
@@ -217,6 +252,8 @@ func (fake *Event) RegisterFilteredBlockEventReturns(result1 fab.Registration, r
 }
 
 func (fake *Event) RegisterFilteredBlockEventReturnsOnCall(i int, result1 fab.Registration, result2 <-chan *fab.FilteredBlockEvent, result3 error) {
+	fake.registerFilteredBlockEventMutex.Lock()
+	defer fake.registerFilteredBlockEventMutex.Unlock()
 	fake.RegisterFilteredBlockEventStub = nil
 	if fake.registerFilteredBlockEventReturnsOnCall == nil {
 		fake.registerFilteredBlockEventReturnsOnCall = make(map[int]struct {
@@ -232,21 +269,22 @@ func (fake *Event) RegisterFilteredBlockEventReturnsOnCall(i int, result1 fab.Re
 	}{result1, result2, result3}
 }
 
-func (fake *Event) RegisterTxStatusEvent(txID string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
+func (fake *Event) RegisterTxStatusEvent(arg1 string) (fab.Registration, <-chan *fab.TxStatusEvent, error) {
 	fake.registerTxStatusEventMutex.Lock()
 	ret, specificReturn := fake.registerTxStatusEventReturnsOnCall[len(fake.registerTxStatusEventArgsForCall)]
 	fake.registerTxStatusEventArgsForCall = append(fake.registerTxStatusEventArgsForCall, struct {
-		txID string
-	}{txID})
-	fake.recordInvocation("RegisterTxStatusEvent", []interface{}{txID})
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("RegisterTxStatusEvent", []interface{}{arg1})
 	fake.registerTxStatusEventMutex.Unlock()
 	if fake.RegisterTxStatusEventStub != nil {
-		return fake.RegisterTxStatusEventStub(txID)
+		return fake.RegisterTxStatusEventStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.registerTxStatusEventReturns.result1, fake.registerTxStatusEventReturns.result2, fake.registerTxStatusEventReturns.result3
+	fakeReturns := fake.registerTxStatusEventReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Event) RegisterTxStatusEventCallCount() int {
@@ -255,13 +293,22 @@ func (fake *Event) RegisterTxStatusEventCallCount() int {
 	return len(fake.registerTxStatusEventArgsForCall)
 }
 
+func (fake *Event) RegisterTxStatusEventCalls(stub func(string) (fab.Registration, <-chan *fab.TxStatusEvent, error)) {
+	fake.registerTxStatusEventMutex.Lock()
+	defer fake.registerTxStatusEventMutex.Unlock()
+	fake.RegisterTxStatusEventStub = stub
+}
+
 func (fake *Event) RegisterTxStatusEventArgsForCall(i int) string {
 	fake.registerTxStatusEventMutex.RLock()
 	defer fake.registerTxStatusEventMutex.RUnlock()
-	return fake.registerTxStatusEventArgsForCall[i].txID
+	argsForCall := fake.registerTxStatusEventArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Event) RegisterTxStatusEventReturns(result1 fab.Registration, result2 <-chan *fab.TxStatusEvent, result3 error) {
+	fake.registerTxStatusEventMutex.Lock()
+	defer fake.registerTxStatusEventMutex.Unlock()
 	fake.RegisterTxStatusEventStub = nil
 	fake.registerTxStatusEventReturns = struct {
 		result1 fab.Registration
@@ -271,6 +318,8 @@ func (fake *Event) RegisterTxStatusEventReturns(result1 fab.Registration, result
 }
 
 func (fake *Event) RegisterTxStatusEventReturnsOnCall(i int, result1 fab.Registration, result2 <-chan *fab.TxStatusEvent, result3 error) {
+	fake.registerTxStatusEventMutex.Lock()
+	defer fake.registerTxStatusEventMutex.Unlock()
 	fake.RegisterTxStatusEventStub = nil
 	if fake.registerTxStatusEventReturnsOnCall == nil {
 		fake.registerTxStatusEventReturnsOnCall = make(map[int]struct {
@@ -286,15 +335,15 @@ func (fake *Event) RegisterTxStatusEventReturnsOnCall(i int, result1 fab.Registr
 	}{result1, result2, result3}
 }
 
-func (fake *Event) Unregister(reg fab.Registration) {
+func (fake *Event) Unregister(arg1 fab.Registration) {
 	fake.unregisterMutex.Lock()
 	fake.unregisterArgsForCall = append(fake.unregisterArgsForCall, struct {
-		reg fab.Registration
-	}{reg})
-	fake.recordInvocation("Unregister", []interface{}{reg})
+		arg1 fab.Registration
+	}{arg1})
+	fake.recordInvocation("Unregister", []interface{}{arg1})
 	fake.unregisterMutex.Unlock()
 	if fake.UnregisterStub != nil {
-		fake.UnregisterStub(reg)
+		fake.UnregisterStub(arg1)
 	}
 }
 
@@ -304,10 +353,17 @@ func (fake *Event) UnregisterCallCount() int {
 	return len(fake.unregisterArgsForCall)
 }
 
+func (fake *Event) UnregisterCalls(stub func(fab.Registration)) {
+	fake.unregisterMutex.Lock()
+	defer fake.unregisterMutex.Unlock()
+	fake.UnregisterStub = stub
+}
+
 func (fake *Event) UnregisterArgsForCall(i int) fab.Registration {
 	fake.unregisterMutex.RLock()
 	defer fake.unregisterMutex.RUnlock()
-	return fake.unregisterArgsForCall[i].reg
+	argsForCall := fake.unregisterArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Event) Invocations() map[string][][]interface{} {

--- a/pkg/fabric/mocks/factory.go
+++ b/pkg/fabric/mocks/factory.go
@@ -8,21 +8,11 @@ import (
 )
 
 type Factory struct {
-	SDKStub        func() (fabric.SDK, error)
-	sDKMutex       sync.RWMutex
-	sDKArgsForCall []struct{}
-	sDKReturns     struct {
-		result1 fabric.SDK
-		result2 error
-	}
-	sDKReturnsOnCall map[int]struct {
-		result1 fabric.SDK
-		result2 error
-	}
 	ChannelStub        func() (fabric.Channel, error)
 	channelMutex       sync.RWMutex
-	channelArgsForCall []struct{}
-	channelReturns     struct {
+	channelArgsForCall []struct {
+	}
+	channelReturns struct {
 		result1 fabric.Channel
 		result2 error
 	}
@@ -32,8 +22,9 @@ type Factory struct {
 	}
 	EventStub        func() (fabric.Event, error)
 	eventMutex       sync.RWMutex
-	eventArgsForCall []struct{}
-	eventReturns     struct {
+	eventArgsForCall []struct {
+	}
+	eventReturns struct {
 		result1 fabric.Event
 		result2 error
 	}
@@ -43,8 +34,9 @@ type Factory struct {
 	}
 	LedgerStub        func() (fabric.Ledger, error)
 	ledgerMutex       sync.RWMutex
-	ledgerArgsForCall []struct{}
-	ledgerReturns     struct {
+	ledgerArgsForCall []struct {
+	}
+	ledgerReturns struct {
 		result1 fabric.Ledger
 		result2 error
 	}
@@ -52,21 +44,11 @@ type Factory struct {
 		result1 fabric.Ledger
 		result2 error
 	}
-	ResourceManagementStub        func() (fabric.ResourceManagement, error)
-	resourceManagementMutex       sync.RWMutex
-	resourceManagementArgsForCall []struct{}
-	resourceManagementReturns     struct {
-		result1 fabric.ResourceManagement
-		result2 error
-	}
-	resourceManagementReturnsOnCall map[int]struct {
-		result1 fabric.ResourceManagement
-		result2 error
-	}
 	MSPStub        func() (fabric.MSP, error)
 	mSPMutex       sync.RWMutex
-	mSPArgsForCall []struct{}
-	mSPReturns     struct {
+	mSPArgsForCall []struct {
+	}
+	mSPReturns struct {
 		result1 fabric.MSP
 		result2 error
 	}
@@ -74,57 +56,39 @@ type Factory struct {
 		result1 fabric.MSP
 		result2 error
 	}
+	ResourceManagementStub        func() (fabric.ResourceManagement, error)
+	resourceManagementMutex       sync.RWMutex
+	resourceManagementArgsForCall []struct {
+	}
+	resourceManagementReturns struct {
+		result1 fabric.ResourceManagement
+		result2 error
+	}
+	resourceManagementReturnsOnCall map[int]struct {
+		result1 fabric.ResourceManagement
+		result2 error
+	}
+	SDKStub        func() (fabric.SDK, error)
+	sDKMutex       sync.RWMutex
+	sDKArgsForCall []struct {
+	}
+	sDKReturns struct {
+		result1 fabric.SDK
+		result2 error
+	}
+	sDKReturnsOnCall map[int]struct {
+		result1 fabric.SDK
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *Factory) SDK() (fabric.SDK, error) {
-	fake.sDKMutex.Lock()
-	ret, specificReturn := fake.sDKReturnsOnCall[len(fake.sDKArgsForCall)]
-	fake.sDKArgsForCall = append(fake.sDKArgsForCall, struct{}{})
-	fake.recordInvocation("SDK", []interface{}{})
-	fake.sDKMutex.Unlock()
-	if fake.SDKStub != nil {
-		return fake.SDKStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.sDKReturns.result1, fake.sDKReturns.result2
-}
-
-func (fake *Factory) SDKCallCount() int {
-	fake.sDKMutex.RLock()
-	defer fake.sDKMutex.RUnlock()
-	return len(fake.sDKArgsForCall)
-}
-
-func (fake *Factory) SDKReturns(result1 fabric.SDK, result2 error) {
-	fake.SDKStub = nil
-	fake.sDKReturns = struct {
-		result1 fabric.SDK
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *Factory) SDKReturnsOnCall(i int, result1 fabric.SDK, result2 error) {
-	fake.SDKStub = nil
-	if fake.sDKReturnsOnCall == nil {
-		fake.sDKReturnsOnCall = make(map[int]struct {
-			result1 fabric.SDK
-			result2 error
-		})
-	}
-	fake.sDKReturnsOnCall[i] = struct {
-		result1 fabric.SDK
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *Factory) Channel() (fabric.Channel, error) {
 	fake.channelMutex.Lock()
 	ret, specificReturn := fake.channelReturnsOnCall[len(fake.channelArgsForCall)]
-	fake.channelArgsForCall = append(fake.channelArgsForCall, struct{}{})
+	fake.channelArgsForCall = append(fake.channelArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Channel", []interface{}{})
 	fake.channelMutex.Unlock()
 	if fake.ChannelStub != nil {
@@ -133,7 +97,8 @@ func (fake *Factory) Channel() (fabric.Channel, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.channelReturns.result1, fake.channelReturns.result2
+	fakeReturns := fake.channelReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Factory) ChannelCallCount() int {
@@ -142,7 +107,15 @@ func (fake *Factory) ChannelCallCount() int {
 	return len(fake.channelArgsForCall)
 }
 
+func (fake *Factory) ChannelCalls(stub func() (fabric.Channel, error)) {
+	fake.channelMutex.Lock()
+	defer fake.channelMutex.Unlock()
+	fake.ChannelStub = stub
+}
+
 func (fake *Factory) ChannelReturns(result1 fabric.Channel, result2 error) {
+	fake.channelMutex.Lock()
+	defer fake.channelMutex.Unlock()
 	fake.ChannelStub = nil
 	fake.channelReturns = struct {
 		result1 fabric.Channel
@@ -151,6 +124,8 @@ func (fake *Factory) ChannelReturns(result1 fabric.Channel, result2 error) {
 }
 
 func (fake *Factory) ChannelReturnsOnCall(i int, result1 fabric.Channel, result2 error) {
+	fake.channelMutex.Lock()
+	defer fake.channelMutex.Unlock()
 	fake.ChannelStub = nil
 	if fake.channelReturnsOnCall == nil {
 		fake.channelReturnsOnCall = make(map[int]struct {
@@ -167,7 +142,8 @@ func (fake *Factory) ChannelReturnsOnCall(i int, result1 fabric.Channel, result2
 func (fake *Factory) Event() (fabric.Event, error) {
 	fake.eventMutex.Lock()
 	ret, specificReturn := fake.eventReturnsOnCall[len(fake.eventArgsForCall)]
-	fake.eventArgsForCall = append(fake.eventArgsForCall, struct{}{})
+	fake.eventArgsForCall = append(fake.eventArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Event", []interface{}{})
 	fake.eventMutex.Unlock()
 	if fake.EventStub != nil {
@@ -176,7 +152,8 @@ func (fake *Factory) Event() (fabric.Event, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.eventReturns.result1, fake.eventReturns.result2
+	fakeReturns := fake.eventReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Factory) EventCallCount() int {
@@ -185,7 +162,15 @@ func (fake *Factory) EventCallCount() int {
 	return len(fake.eventArgsForCall)
 }
 
+func (fake *Factory) EventCalls(stub func() (fabric.Event, error)) {
+	fake.eventMutex.Lock()
+	defer fake.eventMutex.Unlock()
+	fake.EventStub = stub
+}
+
 func (fake *Factory) EventReturns(result1 fabric.Event, result2 error) {
+	fake.eventMutex.Lock()
+	defer fake.eventMutex.Unlock()
 	fake.EventStub = nil
 	fake.eventReturns = struct {
 		result1 fabric.Event
@@ -194,6 +179,8 @@ func (fake *Factory) EventReturns(result1 fabric.Event, result2 error) {
 }
 
 func (fake *Factory) EventReturnsOnCall(i int, result1 fabric.Event, result2 error) {
+	fake.eventMutex.Lock()
+	defer fake.eventMutex.Unlock()
 	fake.EventStub = nil
 	if fake.eventReturnsOnCall == nil {
 		fake.eventReturnsOnCall = make(map[int]struct {
@@ -210,7 +197,8 @@ func (fake *Factory) EventReturnsOnCall(i int, result1 fabric.Event, result2 err
 func (fake *Factory) Ledger() (fabric.Ledger, error) {
 	fake.ledgerMutex.Lock()
 	ret, specificReturn := fake.ledgerReturnsOnCall[len(fake.ledgerArgsForCall)]
-	fake.ledgerArgsForCall = append(fake.ledgerArgsForCall, struct{}{})
+	fake.ledgerArgsForCall = append(fake.ledgerArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Ledger", []interface{}{})
 	fake.ledgerMutex.Unlock()
 	if fake.LedgerStub != nil {
@@ -219,7 +207,8 @@ func (fake *Factory) Ledger() (fabric.Ledger, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.ledgerReturns.result1, fake.ledgerReturns.result2
+	fakeReturns := fake.ledgerReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Factory) LedgerCallCount() int {
@@ -228,7 +217,15 @@ func (fake *Factory) LedgerCallCount() int {
 	return len(fake.ledgerArgsForCall)
 }
 
+func (fake *Factory) LedgerCalls(stub func() (fabric.Ledger, error)) {
+	fake.ledgerMutex.Lock()
+	defer fake.ledgerMutex.Unlock()
+	fake.LedgerStub = stub
+}
+
 func (fake *Factory) LedgerReturns(result1 fabric.Ledger, result2 error) {
+	fake.ledgerMutex.Lock()
+	defer fake.ledgerMutex.Unlock()
 	fake.LedgerStub = nil
 	fake.ledgerReturns = struct {
 		result1 fabric.Ledger
@@ -237,6 +234,8 @@ func (fake *Factory) LedgerReturns(result1 fabric.Ledger, result2 error) {
 }
 
 func (fake *Factory) LedgerReturnsOnCall(i int, result1 fabric.Ledger, result2 error) {
+	fake.ledgerMutex.Lock()
+	defer fake.ledgerMutex.Unlock()
 	fake.LedgerStub = nil
 	if fake.ledgerReturnsOnCall == nil {
 		fake.ledgerReturnsOnCall = make(map[int]struct {
@@ -250,53 +249,11 @@ func (fake *Factory) LedgerReturnsOnCall(i int, result1 fabric.Ledger, result2 e
 	}{result1, result2}
 }
 
-func (fake *Factory) ResourceManagement() (fabric.ResourceManagement, error) {
-	fake.resourceManagementMutex.Lock()
-	ret, specificReturn := fake.resourceManagementReturnsOnCall[len(fake.resourceManagementArgsForCall)]
-	fake.resourceManagementArgsForCall = append(fake.resourceManagementArgsForCall, struct{}{})
-	fake.recordInvocation("ResourceManagement", []interface{}{})
-	fake.resourceManagementMutex.Unlock()
-	if fake.ResourceManagementStub != nil {
-		return fake.ResourceManagementStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.resourceManagementReturns.result1, fake.resourceManagementReturns.result2
-}
-
-func (fake *Factory) ResourceManagementCallCount() int {
-	fake.resourceManagementMutex.RLock()
-	defer fake.resourceManagementMutex.RUnlock()
-	return len(fake.resourceManagementArgsForCall)
-}
-
-func (fake *Factory) ResourceManagementReturns(result1 fabric.ResourceManagement, result2 error) {
-	fake.ResourceManagementStub = nil
-	fake.resourceManagementReturns = struct {
-		result1 fabric.ResourceManagement
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *Factory) ResourceManagementReturnsOnCall(i int, result1 fabric.ResourceManagement, result2 error) {
-	fake.ResourceManagementStub = nil
-	if fake.resourceManagementReturnsOnCall == nil {
-		fake.resourceManagementReturnsOnCall = make(map[int]struct {
-			result1 fabric.ResourceManagement
-			result2 error
-		})
-	}
-	fake.resourceManagementReturnsOnCall[i] = struct {
-		result1 fabric.ResourceManagement
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *Factory) MSP() (fabric.MSP, error) {
 	fake.mSPMutex.Lock()
 	ret, specificReturn := fake.mSPReturnsOnCall[len(fake.mSPArgsForCall)]
-	fake.mSPArgsForCall = append(fake.mSPArgsForCall, struct{}{})
+	fake.mSPArgsForCall = append(fake.mSPArgsForCall, struct {
+	}{})
 	fake.recordInvocation("MSP", []interface{}{})
 	fake.mSPMutex.Unlock()
 	if fake.MSPStub != nil {
@@ -305,7 +262,8 @@ func (fake *Factory) MSP() (fabric.MSP, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.mSPReturns.result1, fake.mSPReturns.result2
+	fakeReturns := fake.mSPReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Factory) MSPCallCount() int {
@@ -314,7 +272,15 @@ func (fake *Factory) MSPCallCount() int {
 	return len(fake.mSPArgsForCall)
 }
 
+func (fake *Factory) MSPCalls(stub func() (fabric.MSP, error)) {
+	fake.mSPMutex.Lock()
+	defer fake.mSPMutex.Unlock()
+	fake.MSPStub = stub
+}
+
 func (fake *Factory) MSPReturns(result1 fabric.MSP, result2 error) {
+	fake.mSPMutex.Lock()
+	defer fake.mSPMutex.Unlock()
 	fake.MSPStub = nil
 	fake.mSPReturns = struct {
 		result1 fabric.MSP
@@ -323,6 +289,8 @@ func (fake *Factory) MSPReturns(result1 fabric.MSP, result2 error) {
 }
 
 func (fake *Factory) MSPReturnsOnCall(i int, result1 fabric.MSP, result2 error) {
+	fake.mSPMutex.Lock()
+	defer fake.mSPMutex.Unlock()
 	fake.MSPStub = nil
 	if fake.mSPReturnsOnCall == nil {
 		fake.mSPReturnsOnCall = make(map[int]struct {
@@ -336,21 +304,131 @@ func (fake *Factory) MSPReturnsOnCall(i int, result1 fabric.MSP, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *Factory) ResourceManagement() (fabric.ResourceManagement, error) {
+	fake.resourceManagementMutex.Lock()
+	ret, specificReturn := fake.resourceManagementReturnsOnCall[len(fake.resourceManagementArgsForCall)]
+	fake.resourceManagementArgsForCall = append(fake.resourceManagementArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ResourceManagement", []interface{}{})
+	fake.resourceManagementMutex.Unlock()
+	if fake.ResourceManagementStub != nil {
+		return fake.ResourceManagementStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.resourceManagementReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Factory) ResourceManagementCallCount() int {
+	fake.resourceManagementMutex.RLock()
+	defer fake.resourceManagementMutex.RUnlock()
+	return len(fake.resourceManagementArgsForCall)
+}
+
+func (fake *Factory) ResourceManagementCalls(stub func() (fabric.ResourceManagement, error)) {
+	fake.resourceManagementMutex.Lock()
+	defer fake.resourceManagementMutex.Unlock()
+	fake.ResourceManagementStub = stub
+}
+
+func (fake *Factory) ResourceManagementReturns(result1 fabric.ResourceManagement, result2 error) {
+	fake.resourceManagementMutex.Lock()
+	defer fake.resourceManagementMutex.Unlock()
+	fake.ResourceManagementStub = nil
+	fake.resourceManagementReturns = struct {
+		result1 fabric.ResourceManagement
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Factory) ResourceManagementReturnsOnCall(i int, result1 fabric.ResourceManagement, result2 error) {
+	fake.resourceManagementMutex.Lock()
+	defer fake.resourceManagementMutex.Unlock()
+	fake.ResourceManagementStub = nil
+	if fake.resourceManagementReturnsOnCall == nil {
+		fake.resourceManagementReturnsOnCall = make(map[int]struct {
+			result1 fabric.ResourceManagement
+			result2 error
+		})
+	}
+	fake.resourceManagementReturnsOnCall[i] = struct {
+		result1 fabric.ResourceManagement
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Factory) SDK() (fabric.SDK, error) {
+	fake.sDKMutex.Lock()
+	ret, specificReturn := fake.sDKReturnsOnCall[len(fake.sDKArgsForCall)]
+	fake.sDKArgsForCall = append(fake.sDKArgsForCall, struct {
+	}{})
+	fake.recordInvocation("SDK", []interface{}{})
+	fake.sDKMutex.Unlock()
+	if fake.SDKStub != nil {
+		return fake.SDKStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.sDKReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Factory) SDKCallCount() int {
+	fake.sDKMutex.RLock()
+	defer fake.sDKMutex.RUnlock()
+	return len(fake.sDKArgsForCall)
+}
+
+func (fake *Factory) SDKCalls(stub func() (fabric.SDK, error)) {
+	fake.sDKMutex.Lock()
+	defer fake.sDKMutex.Unlock()
+	fake.SDKStub = stub
+}
+
+func (fake *Factory) SDKReturns(result1 fabric.SDK, result2 error) {
+	fake.sDKMutex.Lock()
+	defer fake.sDKMutex.Unlock()
+	fake.SDKStub = nil
+	fake.sDKReturns = struct {
+		result1 fabric.SDK
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Factory) SDKReturnsOnCall(i int, result1 fabric.SDK, result2 error) {
+	fake.sDKMutex.Lock()
+	defer fake.sDKMutex.Unlock()
+	fake.SDKStub = nil
+	if fake.sDKReturnsOnCall == nil {
+		fake.sDKReturnsOnCall = make(map[int]struct {
+			result1 fabric.SDK
+			result2 error
+		})
+	}
+	fake.sDKReturnsOnCall[i] = struct {
+		result1 fabric.SDK
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *Factory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.sDKMutex.RLock()
-	defer fake.sDKMutex.RUnlock()
 	fake.channelMutex.RLock()
 	defer fake.channelMutex.RUnlock()
 	fake.eventMutex.RLock()
 	defer fake.eventMutex.RUnlock()
 	fake.ledgerMutex.RLock()
 	defer fake.ledgerMutex.RUnlock()
-	fake.resourceManagementMutex.RLock()
-	defer fake.resourceManagementMutex.RUnlock()
 	fake.mSPMutex.RLock()
 	defer fake.mSPMutex.RUnlock()
+	fake.resourceManagementMutex.RLock()
+	defer fake.resourceManagementMutex.RUnlock()
+	fake.sDKMutex.RLock()
+	defer fake.sDKMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/fabric/mocks/ledger.go
+++ b/pkg/fabric/mocks/ledger.go
@@ -6,17 +6,17 @@ import (
 
 	"github.com/hyperledger/fabric-cli/pkg/fabric"
 	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/ledger"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
 type Ledger struct {
-	QueryBlockStub        func(blockNumber uint64, options ...ledger.RequestOption) (*common.Block, error)
+	QueryBlockStub        func(uint64, ...ledger.RequestOption) (*common.Block, error)
 	queryBlockMutex       sync.RWMutex
 	queryBlockArgsForCall []struct {
-		blockNumber uint64
-		options     []ledger.RequestOption
+		arg1 uint64
+		arg2 []ledger.RequestOption
 	}
 	queryBlockReturns struct {
 		result1 *common.Block
@@ -26,11 +26,11 @@ type Ledger struct {
 		result1 *common.Block
 		result2 error
 	}
-	QueryBlockByHashStub        func(blockHash []byte, options ...ledger.RequestOption) (*common.Block, error)
+	QueryBlockByHashStub        func([]byte, ...ledger.RequestOption) (*common.Block, error)
 	queryBlockByHashMutex       sync.RWMutex
 	queryBlockByHashArgsForCall []struct {
-		blockHash []byte
-		options   []ledger.RequestOption
+		arg1 []byte
+		arg2 []ledger.RequestOption
 	}
 	queryBlockByHashReturns struct {
 		result1 *common.Block
@@ -40,11 +40,11 @@ type Ledger struct {
 		result1 *common.Block
 		result2 error
 	}
-	QueryBlockByTxIDStub        func(txID fab.TransactionID, options ...ledger.RequestOption) (*common.Block, error)
+	QueryBlockByTxIDStub        func(fab.TransactionID, ...ledger.RequestOption) (*common.Block, error)
 	queryBlockByTxIDMutex       sync.RWMutex
 	queryBlockByTxIDArgsForCall []struct {
-		txID    fab.TransactionID
-		options []ledger.RequestOption
+		arg1 fab.TransactionID
+		arg2 []ledger.RequestOption
 	}
 	queryBlockByTxIDReturns struct {
 		result1 *common.Block
@@ -54,10 +54,10 @@ type Ledger struct {
 		result1 *common.Block
 		result2 error
 	}
-	QueryConfigStub        func(options ...ledger.RequestOption) (fab.ChannelCfg, error)
+	QueryConfigStub        func(...ledger.RequestOption) (fab.ChannelCfg, error)
 	queryConfigMutex       sync.RWMutex
 	queryConfigArgsForCall []struct {
-		options []ledger.RequestOption
+		arg1 []ledger.RequestOption
 	}
 	queryConfigReturns struct {
 		result1 fab.ChannelCfg
@@ -67,10 +67,10 @@ type Ledger struct {
 		result1 fab.ChannelCfg
 		result2 error
 	}
-	QueryInfoStub        func(options ...ledger.RequestOption) (*fab.BlockchainInfoResponse, error)
+	QueryInfoStub        func(...ledger.RequestOption) (*fab.BlockchainInfoResponse, error)
 	queryInfoMutex       sync.RWMutex
 	queryInfoArgsForCall []struct {
-		options []ledger.RequestOption
+		arg1 []ledger.RequestOption
 	}
 	queryInfoReturns struct {
 		result1 *fab.BlockchainInfoResponse
@@ -80,40 +80,41 @@ type Ledger struct {
 		result1 *fab.BlockchainInfoResponse
 		result2 error
 	}
-	QueryTransactionStub        func(transactionID fab.TransactionID, options ...ledger.RequestOption) (*pb.ProcessedTransaction, error)
+	QueryTransactionStub        func(fab.TransactionID, ...ledger.RequestOption) (*peer.ProcessedTransaction, error)
 	queryTransactionMutex       sync.RWMutex
 	queryTransactionArgsForCall []struct {
-		transactionID fab.TransactionID
-		options       []ledger.RequestOption
+		arg1 fab.TransactionID
+		arg2 []ledger.RequestOption
 	}
 	queryTransactionReturns struct {
-		result1 *pb.ProcessedTransaction
+		result1 *peer.ProcessedTransaction
 		result2 error
 	}
 	queryTransactionReturnsOnCall map[int]struct {
-		result1 *pb.ProcessedTransaction
+		result1 *peer.ProcessedTransaction
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Ledger) QueryBlock(blockNumber uint64, options ...ledger.RequestOption) (*common.Block, error) {
+func (fake *Ledger) QueryBlock(arg1 uint64, arg2 ...ledger.RequestOption) (*common.Block, error) {
 	fake.queryBlockMutex.Lock()
 	ret, specificReturn := fake.queryBlockReturnsOnCall[len(fake.queryBlockArgsForCall)]
 	fake.queryBlockArgsForCall = append(fake.queryBlockArgsForCall, struct {
-		blockNumber uint64
-		options     []ledger.RequestOption
-	}{blockNumber, options})
-	fake.recordInvocation("QueryBlock", []interface{}{blockNumber, options})
+		arg1 uint64
+		arg2 []ledger.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("QueryBlock", []interface{}{arg1, arg2})
 	fake.queryBlockMutex.Unlock()
 	if fake.QueryBlockStub != nil {
-		return fake.QueryBlockStub(blockNumber, options...)
+		return fake.QueryBlockStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryBlockReturns.result1, fake.queryBlockReturns.result2
+	fakeReturns := fake.queryBlockReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryBlockCallCount() int {
@@ -122,13 +123,22 @@ func (fake *Ledger) QueryBlockCallCount() int {
 	return len(fake.queryBlockArgsForCall)
 }
 
+func (fake *Ledger) QueryBlockCalls(stub func(uint64, ...ledger.RequestOption) (*common.Block, error)) {
+	fake.queryBlockMutex.Lock()
+	defer fake.queryBlockMutex.Unlock()
+	fake.QueryBlockStub = stub
+}
+
 func (fake *Ledger) QueryBlockArgsForCall(i int) (uint64, []ledger.RequestOption) {
 	fake.queryBlockMutex.RLock()
 	defer fake.queryBlockMutex.RUnlock()
-	return fake.queryBlockArgsForCall[i].blockNumber, fake.queryBlockArgsForCall[i].options
+	argsForCall := fake.queryBlockArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Ledger) QueryBlockReturns(result1 *common.Block, result2 error) {
+	fake.queryBlockMutex.Lock()
+	defer fake.queryBlockMutex.Unlock()
 	fake.QueryBlockStub = nil
 	fake.queryBlockReturns = struct {
 		result1 *common.Block
@@ -137,6 +147,8 @@ func (fake *Ledger) QueryBlockReturns(result1 *common.Block, result2 error) {
 }
 
 func (fake *Ledger) QueryBlockReturnsOnCall(i int, result1 *common.Block, result2 error) {
+	fake.queryBlockMutex.Lock()
+	defer fake.queryBlockMutex.Unlock()
 	fake.QueryBlockStub = nil
 	if fake.queryBlockReturnsOnCall == nil {
 		fake.queryBlockReturnsOnCall = make(map[int]struct {
@@ -150,27 +162,28 @@ func (fake *Ledger) QueryBlockReturnsOnCall(i int, result1 *common.Block, result
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryBlockByHash(blockHash []byte, options ...ledger.RequestOption) (*common.Block, error) {
-	var blockHashCopy []byte
-	if blockHash != nil {
-		blockHashCopy = make([]byte, len(blockHash))
-		copy(blockHashCopy, blockHash)
+func (fake *Ledger) QueryBlockByHash(arg1 []byte, arg2 ...ledger.RequestOption) (*common.Block, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
 	}
 	fake.queryBlockByHashMutex.Lock()
 	ret, specificReturn := fake.queryBlockByHashReturnsOnCall[len(fake.queryBlockByHashArgsForCall)]
 	fake.queryBlockByHashArgsForCall = append(fake.queryBlockByHashArgsForCall, struct {
-		blockHash []byte
-		options   []ledger.RequestOption
-	}{blockHashCopy, options})
-	fake.recordInvocation("QueryBlockByHash", []interface{}{blockHashCopy, options})
+		arg1 []byte
+		arg2 []ledger.RequestOption
+	}{arg1Copy, arg2})
+	fake.recordInvocation("QueryBlockByHash", []interface{}{arg1Copy, arg2})
 	fake.queryBlockByHashMutex.Unlock()
 	if fake.QueryBlockByHashStub != nil {
-		return fake.QueryBlockByHashStub(blockHash, options...)
+		return fake.QueryBlockByHashStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryBlockByHashReturns.result1, fake.queryBlockByHashReturns.result2
+	fakeReturns := fake.queryBlockByHashReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryBlockByHashCallCount() int {
@@ -179,13 +192,22 @@ func (fake *Ledger) QueryBlockByHashCallCount() int {
 	return len(fake.queryBlockByHashArgsForCall)
 }
 
+func (fake *Ledger) QueryBlockByHashCalls(stub func([]byte, ...ledger.RequestOption) (*common.Block, error)) {
+	fake.queryBlockByHashMutex.Lock()
+	defer fake.queryBlockByHashMutex.Unlock()
+	fake.QueryBlockByHashStub = stub
+}
+
 func (fake *Ledger) QueryBlockByHashArgsForCall(i int) ([]byte, []ledger.RequestOption) {
 	fake.queryBlockByHashMutex.RLock()
 	defer fake.queryBlockByHashMutex.RUnlock()
-	return fake.queryBlockByHashArgsForCall[i].blockHash, fake.queryBlockByHashArgsForCall[i].options
+	argsForCall := fake.queryBlockByHashArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Ledger) QueryBlockByHashReturns(result1 *common.Block, result2 error) {
+	fake.queryBlockByHashMutex.Lock()
+	defer fake.queryBlockByHashMutex.Unlock()
 	fake.QueryBlockByHashStub = nil
 	fake.queryBlockByHashReturns = struct {
 		result1 *common.Block
@@ -194,6 +216,8 @@ func (fake *Ledger) QueryBlockByHashReturns(result1 *common.Block, result2 error
 }
 
 func (fake *Ledger) QueryBlockByHashReturnsOnCall(i int, result1 *common.Block, result2 error) {
+	fake.queryBlockByHashMutex.Lock()
+	defer fake.queryBlockByHashMutex.Unlock()
 	fake.QueryBlockByHashStub = nil
 	if fake.queryBlockByHashReturnsOnCall == nil {
 		fake.queryBlockByHashReturnsOnCall = make(map[int]struct {
@@ -207,22 +231,23 @@ func (fake *Ledger) QueryBlockByHashReturnsOnCall(i int, result1 *common.Block, 
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryBlockByTxID(txID fab.TransactionID, options ...ledger.RequestOption) (*common.Block, error) {
+func (fake *Ledger) QueryBlockByTxID(arg1 fab.TransactionID, arg2 ...ledger.RequestOption) (*common.Block, error) {
 	fake.queryBlockByTxIDMutex.Lock()
 	ret, specificReturn := fake.queryBlockByTxIDReturnsOnCall[len(fake.queryBlockByTxIDArgsForCall)]
 	fake.queryBlockByTxIDArgsForCall = append(fake.queryBlockByTxIDArgsForCall, struct {
-		txID    fab.TransactionID
-		options []ledger.RequestOption
-	}{txID, options})
-	fake.recordInvocation("QueryBlockByTxID", []interface{}{txID, options})
+		arg1 fab.TransactionID
+		arg2 []ledger.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("QueryBlockByTxID", []interface{}{arg1, arg2})
 	fake.queryBlockByTxIDMutex.Unlock()
 	if fake.QueryBlockByTxIDStub != nil {
-		return fake.QueryBlockByTxIDStub(txID, options...)
+		return fake.QueryBlockByTxIDStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryBlockByTxIDReturns.result1, fake.queryBlockByTxIDReturns.result2
+	fakeReturns := fake.queryBlockByTxIDReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryBlockByTxIDCallCount() int {
@@ -231,13 +256,22 @@ func (fake *Ledger) QueryBlockByTxIDCallCount() int {
 	return len(fake.queryBlockByTxIDArgsForCall)
 }
 
+func (fake *Ledger) QueryBlockByTxIDCalls(stub func(fab.TransactionID, ...ledger.RequestOption) (*common.Block, error)) {
+	fake.queryBlockByTxIDMutex.Lock()
+	defer fake.queryBlockByTxIDMutex.Unlock()
+	fake.QueryBlockByTxIDStub = stub
+}
+
 func (fake *Ledger) QueryBlockByTxIDArgsForCall(i int) (fab.TransactionID, []ledger.RequestOption) {
 	fake.queryBlockByTxIDMutex.RLock()
 	defer fake.queryBlockByTxIDMutex.RUnlock()
-	return fake.queryBlockByTxIDArgsForCall[i].txID, fake.queryBlockByTxIDArgsForCall[i].options
+	argsForCall := fake.queryBlockByTxIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Ledger) QueryBlockByTxIDReturns(result1 *common.Block, result2 error) {
+	fake.queryBlockByTxIDMutex.Lock()
+	defer fake.queryBlockByTxIDMutex.Unlock()
 	fake.QueryBlockByTxIDStub = nil
 	fake.queryBlockByTxIDReturns = struct {
 		result1 *common.Block
@@ -246,6 +280,8 @@ func (fake *Ledger) QueryBlockByTxIDReturns(result1 *common.Block, result2 error
 }
 
 func (fake *Ledger) QueryBlockByTxIDReturnsOnCall(i int, result1 *common.Block, result2 error) {
+	fake.queryBlockByTxIDMutex.Lock()
+	defer fake.queryBlockByTxIDMutex.Unlock()
 	fake.QueryBlockByTxIDStub = nil
 	if fake.queryBlockByTxIDReturnsOnCall == nil {
 		fake.queryBlockByTxIDReturnsOnCall = make(map[int]struct {
@@ -259,21 +295,22 @@ func (fake *Ledger) QueryBlockByTxIDReturnsOnCall(i int, result1 *common.Block, 
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryConfig(options ...ledger.RequestOption) (fab.ChannelCfg, error) {
+func (fake *Ledger) QueryConfig(arg1 ...ledger.RequestOption) (fab.ChannelCfg, error) {
 	fake.queryConfigMutex.Lock()
 	ret, specificReturn := fake.queryConfigReturnsOnCall[len(fake.queryConfigArgsForCall)]
 	fake.queryConfigArgsForCall = append(fake.queryConfigArgsForCall, struct {
-		options []ledger.RequestOption
-	}{options})
-	fake.recordInvocation("QueryConfig", []interface{}{options})
+		arg1 []ledger.RequestOption
+	}{arg1})
+	fake.recordInvocation("QueryConfig", []interface{}{arg1})
 	fake.queryConfigMutex.Unlock()
 	if fake.QueryConfigStub != nil {
-		return fake.QueryConfigStub(options...)
+		return fake.QueryConfigStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryConfigReturns.result1, fake.queryConfigReturns.result2
+	fakeReturns := fake.queryConfigReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryConfigCallCount() int {
@@ -282,13 +319,22 @@ func (fake *Ledger) QueryConfigCallCount() int {
 	return len(fake.queryConfigArgsForCall)
 }
 
+func (fake *Ledger) QueryConfigCalls(stub func(...ledger.RequestOption) (fab.ChannelCfg, error)) {
+	fake.queryConfigMutex.Lock()
+	defer fake.queryConfigMutex.Unlock()
+	fake.QueryConfigStub = stub
+}
+
 func (fake *Ledger) QueryConfigArgsForCall(i int) []ledger.RequestOption {
 	fake.queryConfigMutex.RLock()
 	defer fake.queryConfigMutex.RUnlock()
-	return fake.queryConfigArgsForCall[i].options
+	argsForCall := fake.queryConfigArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Ledger) QueryConfigReturns(result1 fab.ChannelCfg, result2 error) {
+	fake.queryConfigMutex.Lock()
+	defer fake.queryConfigMutex.Unlock()
 	fake.QueryConfigStub = nil
 	fake.queryConfigReturns = struct {
 		result1 fab.ChannelCfg
@@ -297,6 +343,8 @@ func (fake *Ledger) QueryConfigReturns(result1 fab.ChannelCfg, result2 error) {
 }
 
 func (fake *Ledger) QueryConfigReturnsOnCall(i int, result1 fab.ChannelCfg, result2 error) {
+	fake.queryConfigMutex.Lock()
+	defer fake.queryConfigMutex.Unlock()
 	fake.QueryConfigStub = nil
 	if fake.queryConfigReturnsOnCall == nil {
 		fake.queryConfigReturnsOnCall = make(map[int]struct {
@@ -310,21 +358,22 @@ func (fake *Ledger) QueryConfigReturnsOnCall(i int, result1 fab.ChannelCfg, resu
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryInfo(options ...ledger.RequestOption) (*fab.BlockchainInfoResponse, error) {
+func (fake *Ledger) QueryInfo(arg1 ...ledger.RequestOption) (*fab.BlockchainInfoResponse, error) {
 	fake.queryInfoMutex.Lock()
 	ret, specificReturn := fake.queryInfoReturnsOnCall[len(fake.queryInfoArgsForCall)]
 	fake.queryInfoArgsForCall = append(fake.queryInfoArgsForCall, struct {
-		options []ledger.RequestOption
-	}{options})
-	fake.recordInvocation("QueryInfo", []interface{}{options})
+		arg1 []ledger.RequestOption
+	}{arg1})
+	fake.recordInvocation("QueryInfo", []interface{}{arg1})
 	fake.queryInfoMutex.Unlock()
 	if fake.QueryInfoStub != nil {
-		return fake.QueryInfoStub(options...)
+		return fake.QueryInfoStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryInfoReturns.result1, fake.queryInfoReturns.result2
+	fakeReturns := fake.queryInfoReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryInfoCallCount() int {
@@ -333,13 +382,22 @@ func (fake *Ledger) QueryInfoCallCount() int {
 	return len(fake.queryInfoArgsForCall)
 }
 
+func (fake *Ledger) QueryInfoCalls(stub func(...ledger.RequestOption) (*fab.BlockchainInfoResponse, error)) {
+	fake.queryInfoMutex.Lock()
+	defer fake.queryInfoMutex.Unlock()
+	fake.QueryInfoStub = stub
+}
+
 func (fake *Ledger) QueryInfoArgsForCall(i int) []ledger.RequestOption {
 	fake.queryInfoMutex.RLock()
 	defer fake.queryInfoMutex.RUnlock()
-	return fake.queryInfoArgsForCall[i].options
+	argsForCall := fake.queryInfoArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Ledger) QueryInfoReturns(result1 *fab.BlockchainInfoResponse, result2 error) {
+	fake.queryInfoMutex.Lock()
+	defer fake.queryInfoMutex.Unlock()
 	fake.QueryInfoStub = nil
 	fake.queryInfoReturns = struct {
 		result1 *fab.BlockchainInfoResponse
@@ -348,6 +406,8 @@ func (fake *Ledger) QueryInfoReturns(result1 *fab.BlockchainInfoResponse, result
 }
 
 func (fake *Ledger) QueryInfoReturnsOnCall(i int, result1 *fab.BlockchainInfoResponse, result2 error) {
+	fake.queryInfoMutex.Lock()
+	defer fake.queryInfoMutex.Unlock()
 	fake.QueryInfoStub = nil
 	if fake.queryInfoReturnsOnCall == nil {
 		fake.queryInfoReturnsOnCall = make(map[int]struct {
@@ -361,22 +421,23 @@ func (fake *Ledger) QueryInfoReturnsOnCall(i int, result1 *fab.BlockchainInfoRes
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryTransaction(transactionID fab.TransactionID, options ...ledger.RequestOption) (*pb.ProcessedTransaction, error) {
+func (fake *Ledger) QueryTransaction(arg1 fab.TransactionID, arg2 ...ledger.RequestOption) (*peer.ProcessedTransaction, error) {
 	fake.queryTransactionMutex.Lock()
 	ret, specificReturn := fake.queryTransactionReturnsOnCall[len(fake.queryTransactionArgsForCall)]
 	fake.queryTransactionArgsForCall = append(fake.queryTransactionArgsForCall, struct {
-		transactionID fab.TransactionID
-		options       []ledger.RequestOption
-	}{transactionID, options})
-	fake.recordInvocation("QueryTransaction", []interface{}{transactionID, options})
+		arg1 fab.TransactionID
+		arg2 []ledger.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("QueryTransaction", []interface{}{arg1, arg2})
 	fake.queryTransactionMutex.Unlock()
 	if fake.QueryTransactionStub != nil {
-		return fake.QueryTransactionStub(transactionID, options...)
+		return fake.QueryTransactionStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryTransactionReturns.result1, fake.queryTransactionReturns.result2
+	fakeReturns := fake.queryTransactionReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) QueryTransactionCallCount() int {
@@ -385,30 +446,41 @@ func (fake *Ledger) QueryTransactionCallCount() int {
 	return len(fake.queryTransactionArgsForCall)
 }
 
+func (fake *Ledger) QueryTransactionCalls(stub func(fab.TransactionID, ...ledger.RequestOption) (*peer.ProcessedTransaction, error)) {
+	fake.queryTransactionMutex.Lock()
+	defer fake.queryTransactionMutex.Unlock()
+	fake.QueryTransactionStub = stub
+}
+
 func (fake *Ledger) QueryTransactionArgsForCall(i int) (fab.TransactionID, []ledger.RequestOption) {
 	fake.queryTransactionMutex.RLock()
 	defer fake.queryTransactionMutex.RUnlock()
-	return fake.queryTransactionArgsForCall[i].transactionID, fake.queryTransactionArgsForCall[i].options
+	argsForCall := fake.queryTransactionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Ledger) QueryTransactionReturns(result1 *pb.ProcessedTransaction, result2 error) {
+func (fake *Ledger) QueryTransactionReturns(result1 *peer.ProcessedTransaction, result2 error) {
+	fake.queryTransactionMutex.Lock()
+	defer fake.queryTransactionMutex.Unlock()
 	fake.QueryTransactionStub = nil
 	fake.queryTransactionReturns = struct {
-		result1 *pb.ProcessedTransaction
+		result1 *peer.ProcessedTransaction
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *Ledger) QueryTransactionReturnsOnCall(i int, result1 *pb.ProcessedTransaction, result2 error) {
+func (fake *Ledger) QueryTransactionReturnsOnCall(i int, result1 *peer.ProcessedTransaction, result2 error) {
+	fake.queryTransactionMutex.Lock()
+	defer fake.queryTransactionMutex.Unlock()
 	fake.QueryTransactionStub = nil
 	if fake.queryTransactionReturnsOnCall == nil {
 		fake.queryTransactionReturnsOnCall = make(map[int]struct {
-			result1 *pb.ProcessedTransaction
+			result1 *peer.ProcessedTransaction
 			result2 error
 		})
 	}
 	fake.queryTransactionReturnsOnCall[i] = struct {
-		result1 *pb.ProcessedTransaction
+		result1 *peer.ProcessedTransaction
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/fabric/mocks/msp.go
+++ b/pkg/fabric/mocks/msp.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/hyperledger/fabric-cli/pkg/fabric"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/msp"
-	mspctx "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
+	mspa "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 )
 
 type MSP struct {
-	AddAffiliationStub        func(request *msp.AffiliationRequest) (*msp.AffiliationResponse, error)
+	AddAffiliationStub        func(*msp.AffiliationRequest) (*msp.AffiliationResponse, error)
 	addAffiliationMutex       sync.RWMutex
 	addAffiliationArgsForCall []struct {
-		request *msp.AffiliationRequest
+		arg1 *msp.AffiliationRequest
 	}
 	addAffiliationReturns struct {
 		result1 *msp.AffiliationResponse
@@ -23,10 +23,10 @@ type MSP struct {
 		result1 *msp.AffiliationResponse
 		result2 error
 	}
-	CreateIdentityStub        func(request *msp.IdentityRequest) (*msp.IdentityResponse, error)
+	CreateIdentityStub        func(*msp.IdentityRequest) (*msp.IdentityResponse, error)
 	createIdentityMutex       sync.RWMutex
 	createIdentityArgsForCall []struct {
-		request *msp.IdentityRequest
+		arg1 *msp.IdentityRequest
 	}
 	createIdentityReturns struct {
 		result1 *msp.IdentityResponse
@@ -36,24 +36,24 @@ type MSP struct {
 		result1 *msp.IdentityResponse
 		result2 error
 	}
-	CreateSigningIdentityStub        func(opts ...mspctx.SigningIdentityOption) (mspctx.SigningIdentity, error)
+	CreateSigningIdentityStub        func(...mspa.SigningIdentityOption) (mspa.SigningIdentity, error)
 	createSigningIdentityMutex       sync.RWMutex
 	createSigningIdentityArgsForCall []struct {
-		opts []mspctx.SigningIdentityOption
+		arg1 []mspa.SigningIdentityOption
 	}
 	createSigningIdentityReturns struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}
 	createSigningIdentityReturnsOnCall map[int]struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}
-	EnrollStub        func(enrollmentID string, opts ...msp.EnrollmentOption) error
+	EnrollStub        func(string, ...msp.EnrollmentOption) error
 	enrollMutex       sync.RWMutex
 	enrollArgsForCall []struct {
-		enrollmentID string
-		opts         []msp.EnrollmentOption
+		arg1 string
+		arg2 []msp.EnrollmentOption
 	}
 	enrollReturns struct {
 		result1 error
@@ -61,11 +61,11 @@ type MSP struct {
 	enrollReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetAffiliationStub        func(affiliation string, options ...msp.RequestOption) (*msp.AffiliationResponse, error)
+	GetAffiliationStub        func(string, ...msp.RequestOption) (*msp.AffiliationResponse, error)
 	getAffiliationMutex       sync.RWMutex
 	getAffiliationArgsForCall []struct {
-		affiliation string
-		options     []msp.RequestOption
+		arg1 string
+		arg2 []msp.RequestOption
 	}
 	getAffiliationReturns struct {
 		result1 *msp.AffiliationResponse
@@ -75,10 +75,10 @@ type MSP struct {
 		result1 *msp.AffiliationResponse
 		result2 error
 	}
-	GetAllAffiliationsStub        func(options ...msp.RequestOption) (*msp.AffiliationResponse, error)
+	GetAllAffiliationsStub        func(...msp.RequestOption) (*msp.AffiliationResponse, error)
 	getAllAffiliationsMutex       sync.RWMutex
 	getAllAffiliationsArgsForCall []struct {
-		options []msp.RequestOption
+		arg1 []msp.RequestOption
 	}
 	getAllAffiliationsReturns struct {
 		result1 *msp.AffiliationResponse
@@ -88,10 +88,10 @@ type MSP struct {
 		result1 *msp.AffiliationResponse
 		result2 error
 	}
-	GetAllIdentitiesStub        func(options ...msp.RequestOption) ([]*msp.IdentityResponse, error)
+	GetAllIdentitiesStub        func(...msp.RequestOption) ([]*msp.IdentityResponse, error)
 	getAllIdentitiesMutex       sync.RWMutex
 	getAllIdentitiesArgsForCall []struct {
-		options []msp.RequestOption
+		arg1 []msp.RequestOption
 	}
 	getAllIdentitiesReturns struct {
 		result1 []*msp.IdentityResponse
@@ -103,8 +103,9 @@ type MSP struct {
 	}
 	GetCAInfoStub        func() (*msp.GetCAInfoResponse, error)
 	getCAInfoMutex       sync.RWMutex
-	getCAInfoArgsForCall []struct{}
-	getCAInfoReturns     struct {
+	getCAInfoArgsForCall []struct {
+	}
+	getCAInfoReturns struct {
 		result1 *msp.GetCAInfoResponse
 		result2 error
 	}
@@ -112,11 +113,11 @@ type MSP struct {
 		result1 *msp.GetCAInfoResponse
 		result2 error
 	}
-	GetIdentityStub        func(ID string, options ...msp.RequestOption) (*msp.IdentityResponse, error)
+	GetIdentityStub        func(string, ...msp.RequestOption) (*msp.IdentityResponse, error)
 	getIdentityMutex       sync.RWMutex
 	getIdentityArgsForCall []struct {
-		ID      string
-		options []msp.RequestOption
+		arg1 string
+		arg2 []msp.RequestOption
 	}
 	getIdentityReturns struct {
 		result1 *msp.IdentityResponse
@@ -126,23 +127,23 @@ type MSP struct {
 		result1 *msp.IdentityResponse
 		result2 error
 	}
-	GetSigningIdentityStub        func(id string) (mspctx.SigningIdentity, error)
+	GetSigningIdentityStub        func(string) (mspa.SigningIdentity, error)
 	getSigningIdentityMutex       sync.RWMutex
 	getSigningIdentityArgsForCall []struct {
-		id string
+		arg1 string
 	}
 	getSigningIdentityReturns struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}
 	getSigningIdentityReturnsOnCall map[int]struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}
-	ModifyAffiliationStub        func(request *msp.ModifyAffiliationRequest) (*msp.AffiliationResponse, error)
+	ModifyAffiliationStub        func(*msp.ModifyAffiliationRequest) (*msp.AffiliationResponse, error)
 	modifyAffiliationMutex       sync.RWMutex
 	modifyAffiliationArgsForCall []struct {
-		request *msp.ModifyAffiliationRequest
+		arg1 *msp.ModifyAffiliationRequest
 	}
 	modifyAffiliationReturns struct {
 		result1 *msp.AffiliationResponse
@@ -152,10 +153,10 @@ type MSP struct {
 		result1 *msp.AffiliationResponse
 		result2 error
 	}
-	ModifyIdentityStub        func(request *msp.IdentityRequest) (*msp.IdentityResponse, error)
+	ModifyIdentityStub        func(*msp.IdentityRequest) (*msp.IdentityResponse, error)
 	modifyIdentityMutex       sync.RWMutex
 	modifyIdentityArgsForCall []struct {
-		request *msp.IdentityRequest
+		arg1 *msp.IdentityRequest
 	}
 	modifyIdentityReturns struct {
 		result1 *msp.IdentityResponse
@@ -165,11 +166,11 @@ type MSP struct {
 		result1 *msp.IdentityResponse
 		result2 error
 	}
-	ReenrollStub        func(enrollmentID string, opts ...msp.EnrollmentOption) error
+	ReenrollStub        func(string, ...msp.EnrollmentOption) error
 	reenrollMutex       sync.RWMutex
 	reenrollArgsForCall []struct {
-		enrollmentID string
-		opts         []msp.EnrollmentOption
+		arg1 string
+		arg2 []msp.EnrollmentOption
 	}
 	reenrollReturns struct {
 		result1 error
@@ -177,10 +178,10 @@ type MSP struct {
 	reenrollReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RegisterStub        func(request *msp.RegistrationRequest) (string, error)
+	RegisterStub        func(*msp.RegistrationRequest) (string, error)
 	registerMutex       sync.RWMutex
 	registerArgsForCall []struct {
-		request *msp.RegistrationRequest
+		arg1 *msp.RegistrationRequest
 	}
 	registerReturns struct {
 		result1 string
@@ -190,10 +191,10 @@ type MSP struct {
 		result1 string
 		result2 error
 	}
-	RemoveAffiliationStub        func(request *msp.AffiliationRequest) (*msp.AffiliationResponse, error)
+	RemoveAffiliationStub        func(*msp.AffiliationRequest) (*msp.AffiliationResponse, error)
 	removeAffiliationMutex       sync.RWMutex
 	removeAffiliationArgsForCall []struct {
-		request *msp.AffiliationRequest
+		arg1 *msp.AffiliationRequest
 	}
 	removeAffiliationReturns struct {
 		result1 *msp.AffiliationResponse
@@ -203,10 +204,10 @@ type MSP struct {
 		result1 *msp.AffiliationResponse
 		result2 error
 	}
-	RemoveIdentityStub        func(request *msp.RemoveIdentityRequest) (*msp.IdentityResponse, error)
+	RemoveIdentityStub        func(*msp.RemoveIdentityRequest) (*msp.IdentityResponse, error)
 	removeIdentityMutex       sync.RWMutex
 	removeIdentityArgsForCall []struct {
-		request *msp.RemoveIdentityRequest
+		arg1 *msp.RemoveIdentityRequest
 	}
 	removeIdentityReturns struct {
 		result1 *msp.IdentityResponse
@@ -216,10 +217,10 @@ type MSP struct {
 		result1 *msp.IdentityResponse
 		result2 error
 	}
-	RevokeStub        func(request *msp.RevocationRequest) (*msp.RevocationResponse, error)
+	RevokeStub        func(*msp.RevocationRequest) (*msp.RevocationResponse, error)
 	revokeMutex       sync.RWMutex
 	revokeArgsForCall []struct {
-		request *msp.RevocationRequest
+		arg1 *msp.RevocationRequest
 	}
 	revokeReturns struct {
 		result1 *msp.RevocationResponse
@@ -233,21 +234,22 @@ type MSP struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *MSP) AddAffiliation(request *msp.AffiliationRequest) (*msp.AffiliationResponse, error) {
+func (fake *MSP) AddAffiliation(arg1 *msp.AffiliationRequest) (*msp.AffiliationResponse, error) {
 	fake.addAffiliationMutex.Lock()
 	ret, specificReturn := fake.addAffiliationReturnsOnCall[len(fake.addAffiliationArgsForCall)]
 	fake.addAffiliationArgsForCall = append(fake.addAffiliationArgsForCall, struct {
-		request *msp.AffiliationRequest
-	}{request})
-	fake.recordInvocation("AddAffiliation", []interface{}{request})
+		arg1 *msp.AffiliationRequest
+	}{arg1})
+	fake.recordInvocation("AddAffiliation", []interface{}{arg1})
 	fake.addAffiliationMutex.Unlock()
 	if fake.AddAffiliationStub != nil {
-		return fake.AddAffiliationStub(request)
+		return fake.AddAffiliationStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.addAffiliationReturns.result1, fake.addAffiliationReturns.result2
+	fakeReturns := fake.addAffiliationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) AddAffiliationCallCount() int {
@@ -256,13 +258,22 @@ func (fake *MSP) AddAffiliationCallCount() int {
 	return len(fake.addAffiliationArgsForCall)
 }
 
+func (fake *MSP) AddAffiliationCalls(stub func(*msp.AffiliationRequest) (*msp.AffiliationResponse, error)) {
+	fake.addAffiliationMutex.Lock()
+	defer fake.addAffiliationMutex.Unlock()
+	fake.AddAffiliationStub = stub
+}
+
 func (fake *MSP) AddAffiliationArgsForCall(i int) *msp.AffiliationRequest {
 	fake.addAffiliationMutex.RLock()
 	defer fake.addAffiliationMutex.RUnlock()
-	return fake.addAffiliationArgsForCall[i].request
+	argsForCall := fake.addAffiliationArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) AddAffiliationReturns(result1 *msp.AffiliationResponse, result2 error) {
+	fake.addAffiliationMutex.Lock()
+	defer fake.addAffiliationMutex.Unlock()
 	fake.AddAffiliationStub = nil
 	fake.addAffiliationReturns = struct {
 		result1 *msp.AffiliationResponse
@@ -271,6 +282,8 @@ func (fake *MSP) AddAffiliationReturns(result1 *msp.AffiliationResponse, result2
 }
 
 func (fake *MSP) AddAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResponse, result2 error) {
+	fake.addAffiliationMutex.Lock()
+	defer fake.addAffiliationMutex.Unlock()
 	fake.AddAffiliationStub = nil
 	if fake.addAffiliationReturnsOnCall == nil {
 		fake.addAffiliationReturnsOnCall = make(map[int]struct {
@@ -284,21 +297,22 @@ func (fake *MSP) AddAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResp
 	}{result1, result2}
 }
 
-func (fake *MSP) CreateIdentity(request *msp.IdentityRequest) (*msp.IdentityResponse, error) {
+func (fake *MSP) CreateIdentity(arg1 *msp.IdentityRequest) (*msp.IdentityResponse, error) {
 	fake.createIdentityMutex.Lock()
 	ret, specificReturn := fake.createIdentityReturnsOnCall[len(fake.createIdentityArgsForCall)]
 	fake.createIdentityArgsForCall = append(fake.createIdentityArgsForCall, struct {
-		request *msp.IdentityRequest
-	}{request})
-	fake.recordInvocation("CreateIdentity", []interface{}{request})
+		arg1 *msp.IdentityRequest
+	}{arg1})
+	fake.recordInvocation("CreateIdentity", []interface{}{arg1})
 	fake.createIdentityMutex.Unlock()
 	if fake.CreateIdentityStub != nil {
-		return fake.CreateIdentityStub(request)
+		return fake.CreateIdentityStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createIdentityReturns.result1, fake.createIdentityReturns.result2
+	fakeReturns := fake.createIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) CreateIdentityCallCount() int {
@@ -307,13 +321,22 @@ func (fake *MSP) CreateIdentityCallCount() int {
 	return len(fake.createIdentityArgsForCall)
 }
 
+func (fake *MSP) CreateIdentityCalls(stub func(*msp.IdentityRequest) (*msp.IdentityResponse, error)) {
+	fake.createIdentityMutex.Lock()
+	defer fake.createIdentityMutex.Unlock()
+	fake.CreateIdentityStub = stub
+}
+
 func (fake *MSP) CreateIdentityArgsForCall(i int) *msp.IdentityRequest {
 	fake.createIdentityMutex.RLock()
 	defer fake.createIdentityMutex.RUnlock()
-	return fake.createIdentityArgsForCall[i].request
+	argsForCall := fake.createIdentityArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) CreateIdentityReturns(result1 *msp.IdentityResponse, result2 error) {
+	fake.createIdentityMutex.Lock()
+	defer fake.createIdentityMutex.Unlock()
 	fake.CreateIdentityStub = nil
 	fake.createIdentityReturns = struct {
 		result1 *msp.IdentityResponse
@@ -322,6 +345,8 @@ func (fake *MSP) CreateIdentityReturns(result1 *msp.IdentityResponse, result2 er
 }
 
 func (fake *MSP) CreateIdentityReturnsOnCall(i int, result1 *msp.IdentityResponse, result2 error) {
+	fake.createIdentityMutex.Lock()
+	defer fake.createIdentityMutex.Unlock()
 	fake.CreateIdentityStub = nil
 	if fake.createIdentityReturnsOnCall == nil {
 		fake.createIdentityReturnsOnCall = make(map[int]struct {
@@ -335,21 +360,22 @@ func (fake *MSP) CreateIdentityReturnsOnCall(i int, result1 *msp.IdentityRespons
 	}{result1, result2}
 }
 
-func (fake *MSP) CreateSigningIdentity(opts ...mspctx.SigningIdentityOption) (mspctx.SigningIdentity, error) {
+func (fake *MSP) CreateSigningIdentity(arg1 ...mspa.SigningIdentityOption) (mspa.SigningIdentity, error) {
 	fake.createSigningIdentityMutex.Lock()
 	ret, specificReturn := fake.createSigningIdentityReturnsOnCall[len(fake.createSigningIdentityArgsForCall)]
 	fake.createSigningIdentityArgsForCall = append(fake.createSigningIdentityArgsForCall, struct {
-		opts []mspctx.SigningIdentityOption
-	}{opts})
-	fake.recordInvocation("CreateSigningIdentity", []interface{}{opts})
+		arg1 []mspa.SigningIdentityOption
+	}{arg1})
+	fake.recordInvocation("CreateSigningIdentity", []interface{}{arg1})
 	fake.createSigningIdentityMutex.Unlock()
 	if fake.CreateSigningIdentityStub != nil {
-		return fake.CreateSigningIdentityStub(opts...)
+		return fake.CreateSigningIdentityStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createSigningIdentityReturns.result1, fake.createSigningIdentityReturns.result2
+	fakeReturns := fake.createSigningIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) CreateSigningIdentityCallCount() int {
@@ -358,50 +384,62 @@ func (fake *MSP) CreateSigningIdentityCallCount() int {
 	return len(fake.createSigningIdentityArgsForCall)
 }
 
-func (fake *MSP) CreateSigningIdentityArgsForCall(i int) []mspctx.SigningIdentityOption {
-	fake.createSigningIdentityMutex.RLock()
-	defer fake.createSigningIdentityMutex.RUnlock()
-	return fake.createSigningIdentityArgsForCall[i].opts
+func (fake *MSP) CreateSigningIdentityCalls(stub func(...mspa.SigningIdentityOption) (mspa.SigningIdentity, error)) {
+	fake.createSigningIdentityMutex.Lock()
+	defer fake.createSigningIdentityMutex.Unlock()
+	fake.CreateSigningIdentityStub = stub
 }
 
-func (fake *MSP) CreateSigningIdentityReturns(result1 mspctx.SigningIdentity, result2 error) {
+func (fake *MSP) CreateSigningIdentityArgsForCall(i int) []mspa.SigningIdentityOption {
+	fake.createSigningIdentityMutex.RLock()
+	defer fake.createSigningIdentityMutex.RUnlock()
+	argsForCall := fake.createSigningIdentityArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *MSP) CreateSigningIdentityReturns(result1 mspa.SigningIdentity, result2 error) {
+	fake.createSigningIdentityMutex.Lock()
+	defer fake.createSigningIdentityMutex.Unlock()
 	fake.CreateSigningIdentityStub = nil
 	fake.createSigningIdentityReturns = struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *MSP) CreateSigningIdentityReturnsOnCall(i int, result1 mspctx.SigningIdentity, result2 error) {
+func (fake *MSP) CreateSigningIdentityReturnsOnCall(i int, result1 mspa.SigningIdentity, result2 error) {
+	fake.createSigningIdentityMutex.Lock()
+	defer fake.createSigningIdentityMutex.Unlock()
 	fake.CreateSigningIdentityStub = nil
 	if fake.createSigningIdentityReturnsOnCall == nil {
 		fake.createSigningIdentityReturnsOnCall = make(map[int]struct {
-			result1 mspctx.SigningIdentity
+			result1 mspa.SigningIdentity
 			result2 error
 		})
 	}
 	fake.createSigningIdentityReturnsOnCall[i] = struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *MSP) Enroll(enrollmentID string, opts ...msp.EnrollmentOption) error {
+func (fake *MSP) Enroll(arg1 string, arg2 ...msp.EnrollmentOption) error {
 	fake.enrollMutex.Lock()
 	ret, specificReturn := fake.enrollReturnsOnCall[len(fake.enrollArgsForCall)]
 	fake.enrollArgsForCall = append(fake.enrollArgsForCall, struct {
-		enrollmentID string
-		opts         []msp.EnrollmentOption
-	}{enrollmentID, opts})
-	fake.recordInvocation("Enroll", []interface{}{enrollmentID, opts})
+		arg1 string
+		arg2 []msp.EnrollmentOption
+	}{arg1, arg2})
+	fake.recordInvocation("Enroll", []interface{}{arg1, arg2})
 	fake.enrollMutex.Unlock()
 	if fake.EnrollStub != nil {
-		return fake.EnrollStub(enrollmentID, opts...)
+		return fake.EnrollStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.enrollReturns.result1
+	fakeReturns := fake.enrollReturns
+	return fakeReturns.result1
 }
 
 func (fake *MSP) EnrollCallCount() int {
@@ -410,13 +448,22 @@ func (fake *MSP) EnrollCallCount() int {
 	return len(fake.enrollArgsForCall)
 }
 
+func (fake *MSP) EnrollCalls(stub func(string, ...msp.EnrollmentOption) error) {
+	fake.enrollMutex.Lock()
+	defer fake.enrollMutex.Unlock()
+	fake.EnrollStub = stub
+}
+
 func (fake *MSP) EnrollArgsForCall(i int) (string, []msp.EnrollmentOption) {
 	fake.enrollMutex.RLock()
 	defer fake.enrollMutex.RUnlock()
-	return fake.enrollArgsForCall[i].enrollmentID, fake.enrollArgsForCall[i].opts
+	argsForCall := fake.enrollArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *MSP) EnrollReturns(result1 error) {
+	fake.enrollMutex.Lock()
+	defer fake.enrollMutex.Unlock()
 	fake.EnrollStub = nil
 	fake.enrollReturns = struct {
 		result1 error
@@ -424,6 +471,8 @@ func (fake *MSP) EnrollReturns(result1 error) {
 }
 
 func (fake *MSP) EnrollReturnsOnCall(i int, result1 error) {
+	fake.enrollMutex.Lock()
+	defer fake.enrollMutex.Unlock()
 	fake.EnrollStub = nil
 	if fake.enrollReturnsOnCall == nil {
 		fake.enrollReturnsOnCall = make(map[int]struct {
@@ -435,22 +484,23 @@ func (fake *MSP) EnrollReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *MSP) GetAffiliation(affiliation string, options ...msp.RequestOption) (*msp.AffiliationResponse, error) {
+func (fake *MSP) GetAffiliation(arg1 string, arg2 ...msp.RequestOption) (*msp.AffiliationResponse, error) {
 	fake.getAffiliationMutex.Lock()
 	ret, specificReturn := fake.getAffiliationReturnsOnCall[len(fake.getAffiliationArgsForCall)]
 	fake.getAffiliationArgsForCall = append(fake.getAffiliationArgsForCall, struct {
-		affiliation string
-		options     []msp.RequestOption
-	}{affiliation, options})
-	fake.recordInvocation("GetAffiliation", []interface{}{affiliation, options})
+		arg1 string
+		arg2 []msp.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("GetAffiliation", []interface{}{arg1, arg2})
 	fake.getAffiliationMutex.Unlock()
 	if fake.GetAffiliationStub != nil {
-		return fake.GetAffiliationStub(affiliation, options...)
+		return fake.GetAffiliationStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getAffiliationReturns.result1, fake.getAffiliationReturns.result2
+	fakeReturns := fake.getAffiliationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetAffiliationCallCount() int {
@@ -459,13 +509,22 @@ func (fake *MSP) GetAffiliationCallCount() int {
 	return len(fake.getAffiliationArgsForCall)
 }
 
+func (fake *MSP) GetAffiliationCalls(stub func(string, ...msp.RequestOption) (*msp.AffiliationResponse, error)) {
+	fake.getAffiliationMutex.Lock()
+	defer fake.getAffiliationMutex.Unlock()
+	fake.GetAffiliationStub = stub
+}
+
 func (fake *MSP) GetAffiliationArgsForCall(i int) (string, []msp.RequestOption) {
 	fake.getAffiliationMutex.RLock()
 	defer fake.getAffiliationMutex.RUnlock()
-	return fake.getAffiliationArgsForCall[i].affiliation, fake.getAffiliationArgsForCall[i].options
+	argsForCall := fake.getAffiliationArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *MSP) GetAffiliationReturns(result1 *msp.AffiliationResponse, result2 error) {
+	fake.getAffiliationMutex.Lock()
+	defer fake.getAffiliationMutex.Unlock()
 	fake.GetAffiliationStub = nil
 	fake.getAffiliationReturns = struct {
 		result1 *msp.AffiliationResponse
@@ -474,6 +533,8 @@ func (fake *MSP) GetAffiliationReturns(result1 *msp.AffiliationResponse, result2
 }
 
 func (fake *MSP) GetAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResponse, result2 error) {
+	fake.getAffiliationMutex.Lock()
+	defer fake.getAffiliationMutex.Unlock()
 	fake.GetAffiliationStub = nil
 	if fake.getAffiliationReturnsOnCall == nil {
 		fake.getAffiliationReturnsOnCall = make(map[int]struct {
@@ -487,21 +548,22 @@ func (fake *MSP) GetAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResp
 	}{result1, result2}
 }
 
-func (fake *MSP) GetAllAffiliations(options ...msp.RequestOption) (*msp.AffiliationResponse, error) {
+func (fake *MSP) GetAllAffiliations(arg1 ...msp.RequestOption) (*msp.AffiliationResponse, error) {
 	fake.getAllAffiliationsMutex.Lock()
 	ret, specificReturn := fake.getAllAffiliationsReturnsOnCall[len(fake.getAllAffiliationsArgsForCall)]
 	fake.getAllAffiliationsArgsForCall = append(fake.getAllAffiliationsArgsForCall, struct {
-		options []msp.RequestOption
-	}{options})
-	fake.recordInvocation("GetAllAffiliations", []interface{}{options})
+		arg1 []msp.RequestOption
+	}{arg1})
+	fake.recordInvocation("GetAllAffiliations", []interface{}{arg1})
 	fake.getAllAffiliationsMutex.Unlock()
 	if fake.GetAllAffiliationsStub != nil {
-		return fake.GetAllAffiliationsStub(options...)
+		return fake.GetAllAffiliationsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getAllAffiliationsReturns.result1, fake.getAllAffiliationsReturns.result2
+	fakeReturns := fake.getAllAffiliationsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetAllAffiliationsCallCount() int {
@@ -510,13 +572,22 @@ func (fake *MSP) GetAllAffiliationsCallCount() int {
 	return len(fake.getAllAffiliationsArgsForCall)
 }
 
+func (fake *MSP) GetAllAffiliationsCalls(stub func(...msp.RequestOption) (*msp.AffiliationResponse, error)) {
+	fake.getAllAffiliationsMutex.Lock()
+	defer fake.getAllAffiliationsMutex.Unlock()
+	fake.GetAllAffiliationsStub = stub
+}
+
 func (fake *MSP) GetAllAffiliationsArgsForCall(i int) []msp.RequestOption {
 	fake.getAllAffiliationsMutex.RLock()
 	defer fake.getAllAffiliationsMutex.RUnlock()
-	return fake.getAllAffiliationsArgsForCall[i].options
+	argsForCall := fake.getAllAffiliationsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) GetAllAffiliationsReturns(result1 *msp.AffiliationResponse, result2 error) {
+	fake.getAllAffiliationsMutex.Lock()
+	defer fake.getAllAffiliationsMutex.Unlock()
 	fake.GetAllAffiliationsStub = nil
 	fake.getAllAffiliationsReturns = struct {
 		result1 *msp.AffiliationResponse
@@ -525,6 +596,8 @@ func (fake *MSP) GetAllAffiliationsReturns(result1 *msp.AffiliationResponse, res
 }
 
 func (fake *MSP) GetAllAffiliationsReturnsOnCall(i int, result1 *msp.AffiliationResponse, result2 error) {
+	fake.getAllAffiliationsMutex.Lock()
+	defer fake.getAllAffiliationsMutex.Unlock()
 	fake.GetAllAffiliationsStub = nil
 	if fake.getAllAffiliationsReturnsOnCall == nil {
 		fake.getAllAffiliationsReturnsOnCall = make(map[int]struct {
@@ -538,21 +611,22 @@ func (fake *MSP) GetAllAffiliationsReturnsOnCall(i int, result1 *msp.Affiliation
 	}{result1, result2}
 }
 
-func (fake *MSP) GetAllIdentities(options ...msp.RequestOption) ([]*msp.IdentityResponse, error) {
+func (fake *MSP) GetAllIdentities(arg1 ...msp.RequestOption) ([]*msp.IdentityResponse, error) {
 	fake.getAllIdentitiesMutex.Lock()
 	ret, specificReturn := fake.getAllIdentitiesReturnsOnCall[len(fake.getAllIdentitiesArgsForCall)]
 	fake.getAllIdentitiesArgsForCall = append(fake.getAllIdentitiesArgsForCall, struct {
-		options []msp.RequestOption
-	}{options})
-	fake.recordInvocation("GetAllIdentities", []interface{}{options})
+		arg1 []msp.RequestOption
+	}{arg1})
+	fake.recordInvocation("GetAllIdentities", []interface{}{arg1})
 	fake.getAllIdentitiesMutex.Unlock()
 	if fake.GetAllIdentitiesStub != nil {
-		return fake.GetAllIdentitiesStub(options...)
+		return fake.GetAllIdentitiesStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getAllIdentitiesReturns.result1, fake.getAllIdentitiesReturns.result2
+	fakeReturns := fake.getAllIdentitiesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetAllIdentitiesCallCount() int {
@@ -561,13 +635,22 @@ func (fake *MSP) GetAllIdentitiesCallCount() int {
 	return len(fake.getAllIdentitiesArgsForCall)
 }
 
+func (fake *MSP) GetAllIdentitiesCalls(stub func(...msp.RequestOption) ([]*msp.IdentityResponse, error)) {
+	fake.getAllIdentitiesMutex.Lock()
+	defer fake.getAllIdentitiesMutex.Unlock()
+	fake.GetAllIdentitiesStub = stub
+}
+
 func (fake *MSP) GetAllIdentitiesArgsForCall(i int) []msp.RequestOption {
 	fake.getAllIdentitiesMutex.RLock()
 	defer fake.getAllIdentitiesMutex.RUnlock()
-	return fake.getAllIdentitiesArgsForCall[i].options
+	argsForCall := fake.getAllIdentitiesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) GetAllIdentitiesReturns(result1 []*msp.IdentityResponse, result2 error) {
+	fake.getAllIdentitiesMutex.Lock()
+	defer fake.getAllIdentitiesMutex.Unlock()
 	fake.GetAllIdentitiesStub = nil
 	fake.getAllIdentitiesReturns = struct {
 		result1 []*msp.IdentityResponse
@@ -576,6 +659,8 @@ func (fake *MSP) GetAllIdentitiesReturns(result1 []*msp.IdentityResponse, result
 }
 
 func (fake *MSP) GetAllIdentitiesReturnsOnCall(i int, result1 []*msp.IdentityResponse, result2 error) {
+	fake.getAllIdentitiesMutex.Lock()
+	defer fake.getAllIdentitiesMutex.Unlock()
 	fake.GetAllIdentitiesStub = nil
 	if fake.getAllIdentitiesReturnsOnCall == nil {
 		fake.getAllIdentitiesReturnsOnCall = make(map[int]struct {
@@ -592,7 +677,8 @@ func (fake *MSP) GetAllIdentitiesReturnsOnCall(i int, result1 []*msp.IdentityRes
 func (fake *MSP) GetCAInfo() (*msp.GetCAInfoResponse, error) {
 	fake.getCAInfoMutex.Lock()
 	ret, specificReturn := fake.getCAInfoReturnsOnCall[len(fake.getCAInfoArgsForCall)]
-	fake.getCAInfoArgsForCall = append(fake.getCAInfoArgsForCall, struct{}{})
+	fake.getCAInfoArgsForCall = append(fake.getCAInfoArgsForCall, struct {
+	}{})
 	fake.recordInvocation("GetCAInfo", []interface{}{})
 	fake.getCAInfoMutex.Unlock()
 	if fake.GetCAInfoStub != nil {
@@ -601,7 +687,8 @@ func (fake *MSP) GetCAInfo() (*msp.GetCAInfoResponse, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getCAInfoReturns.result1, fake.getCAInfoReturns.result2
+	fakeReturns := fake.getCAInfoReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetCAInfoCallCount() int {
@@ -610,7 +697,15 @@ func (fake *MSP) GetCAInfoCallCount() int {
 	return len(fake.getCAInfoArgsForCall)
 }
 
+func (fake *MSP) GetCAInfoCalls(stub func() (*msp.GetCAInfoResponse, error)) {
+	fake.getCAInfoMutex.Lock()
+	defer fake.getCAInfoMutex.Unlock()
+	fake.GetCAInfoStub = stub
+}
+
 func (fake *MSP) GetCAInfoReturns(result1 *msp.GetCAInfoResponse, result2 error) {
+	fake.getCAInfoMutex.Lock()
+	defer fake.getCAInfoMutex.Unlock()
 	fake.GetCAInfoStub = nil
 	fake.getCAInfoReturns = struct {
 		result1 *msp.GetCAInfoResponse
@@ -619,6 +714,8 @@ func (fake *MSP) GetCAInfoReturns(result1 *msp.GetCAInfoResponse, result2 error)
 }
 
 func (fake *MSP) GetCAInfoReturnsOnCall(i int, result1 *msp.GetCAInfoResponse, result2 error) {
+	fake.getCAInfoMutex.Lock()
+	defer fake.getCAInfoMutex.Unlock()
 	fake.GetCAInfoStub = nil
 	if fake.getCAInfoReturnsOnCall == nil {
 		fake.getCAInfoReturnsOnCall = make(map[int]struct {
@@ -632,22 +729,23 @@ func (fake *MSP) GetCAInfoReturnsOnCall(i int, result1 *msp.GetCAInfoResponse, r
 	}{result1, result2}
 }
 
-func (fake *MSP) GetIdentity(ID string, options ...msp.RequestOption) (*msp.IdentityResponse, error) {
+func (fake *MSP) GetIdentity(arg1 string, arg2 ...msp.RequestOption) (*msp.IdentityResponse, error) {
 	fake.getIdentityMutex.Lock()
 	ret, specificReturn := fake.getIdentityReturnsOnCall[len(fake.getIdentityArgsForCall)]
 	fake.getIdentityArgsForCall = append(fake.getIdentityArgsForCall, struct {
-		ID      string
-		options []msp.RequestOption
-	}{ID, options})
-	fake.recordInvocation("GetIdentity", []interface{}{ID, options})
+		arg1 string
+		arg2 []msp.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("GetIdentity", []interface{}{arg1, arg2})
 	fake.getIdentityMutex.Unlock()
 	if fake.GetIdentityStub != nil {
-		return fake.GetIdentityStub(ID, options...)
+		return fake.GetIdentityStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getIdentityReturns.result1, fake.getIdentityReturns.result2
+	fakeReturns := fake.getIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetIdentityCallCount() int {
@@ -656,13 +754,22 @@ func (fake *MSP) GetIdentityCallCount() int {
 	return len(fake.getIdentityArgsForCall)
 }
 
+func (fake *MSP) GetIdentityCalls(stub func(string, ...msp.RequestOption) (*msp.IdentityResponse, error)) {
+	fake.getIdentityMutex.Lock()
+	defer fake.getIdentityMutex.Unlock()
+	fake.GetIdentityStub = stub
+}
+
 func (fake *MSP) GetIdentityArgsForCall(i int) (string, []msp.RequestOption) {
 	fake.getIdentityMutex.RLock()
 	defer fake.getIdentityMutex.RUnlock()
-	return fake.getIdentityArgsForCall[i].ID, fake.getIdentityArgsForCall[i].options
+	argsForCall := fake.getIdentityArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *MSP) GetIdentityReturns(result1 *msp.IdentityResponse, result2 error) {
+	fake.getIdentityMutex.Lock()
+	defer fake.getIdentityMutex.Unlock()
 	fake.GetIdentityStub = nil
 	fake.getIdentityReturns = struct {
 		result1 *msp.IdentityResponse
@@ -671,6 +778,8 @@ func (fake *MSP) GetIdentityReturns(result1 *msp.IdentityResponse, result2 error
 }
 
 func (fake *MSP) GetIdentityReturnsOnCall(i int, result1 *msp.IdentityResponse, result2 error) {
+	fake.getIdentityMutex.Lock()
+	defer fake.getIdentityMutex.Unlock()
 	fake.GetIdentityStub = nil
 	if fake.getIdentityReturnsOnCall == nil {
 		fake.getIdentityReturnsOnCall = make(map[int]struct {
@@ -684,21 +793,22 @@ func (fake *MSP) GetIdentityReturnsOnCall(i int, result1 *msp.IdentityResponse, 
 	}{result1, result2}
 }
 
-func (fake *MSP) GetSigningIdentity(id string) (mspctx.SigningIdentity, error) {
+func (fake *MSP) GetSigningIdentity(arg1 string) (mspa.SigningIdentity, error) {
 	fake.getSigningIdentityMutex.Lock()
 	ret, specificReturn := fake.getSigningIdentityReturnsOnCall[len(fake.getSigningIdentityArgsForCall)]
 	fake.getSigningIdentityArgsForCall = append(fake.getSigningIdentityArgsForCall, struct {
-		id string
-	}{id})
-	fake.recordInvocation("GetSigningIdentity", []interface{}{id})
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetSigningIdentity", []interface{}{arg1})
 	fake.getSigningIdentityMutex.Unlock()
 	if fake.GetSigningIdentityStub != nil {
-		return fake.GetSigningIdentityStub(id)
+		return fake.GetSigningIdentityStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getSigningIdentityReturns.result1, fake.getSigningIdentityReturns.result2
+	fakeReturns := fake.getSigningIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) GetSigningIdentityCallCount() int {
@@ -707,49 +817,61 @@ func (fake *MSP) GetSigningIdentityCallCount() int {
 	return len(fake.getSigningIdentityArgsForCall)
 }
 
+func (fake *MSP) GetSigningIdentityCalls(stub func(string) (mspa.SigningIdentity, error)) {
+	fake.getSigningIdentityMutex.Lock()
+	defer fake.getSigningIdentityMutex.Unlock()
+	fake.GetSigningIdentityStub = stub
+}
+
 func (fake *MSP) GetSigningIdentityArgsForCall(i int) string {
 	fake.getSigningIdentityMutex.RLock()
 	defer fake.getSigningIdentityMutex.RUnlock()
-	return fake.getSigningIdentityArgsForCall[i].id
+	argsForCall := fake.getSigningIdentityArgsForCall[i]
+	return argsForCall.arg1
 }
 
-func (fake *MSP) GetSigningIdentityReturns(result1 mspctx.SigningIdentity, result2 error) {
+func (fake *MSP) GetSigningIdentityReturns(result1 mspa.SigningIdentity, result2 error) {
+	fake.getSigningIdentityMutex.Lock()
+	defer fake.getSigningIdentityMutex.Unlock()
 	fake.GetSigningIdentityStub = nil
 	fake.getSigningIdentityReturns = struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *MSP) GetSigningIdentityReturnsOnCall(i int, result1 mspctx.SigningIdentity, result2 error) {
+func (fake *MSP) GetSigningIdentityReturnsOnCall(i int, result1 mspa.SigningIdentity, result2 error) {
+	fake.getSigningIdentityMutex.Lock()
+	defer fake.getSigningIdentityMutex.Unlock()
 	fake.GetSigningIdentityStub = nil
 	if fake.getSigningIdentityReturnsOnCall == nil {
 		fake.getSigningIdentityReturnsOnCall = make(map[int]struct {
-			result1 mspctx.SigningIdentity
+			result1 mspa.SigningIdentity
 			result2 error
 		})
 	}
 	fake.getSigningIdentityReturnsOnCall[i] = struct {
-		result1 mspctx.SigningIdentity
+		result1 mspa.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *MSP) ModifyAffiliation(request *msp.ModifyAffiliationRequest) (*msp.AffiliationResponse, error) {
+func (fake *MSP) ModifyAffiliation(arg1 *msp.ModifyAffiliationRequest) (*msp.AffiliationResponse, error) {
 	fake.modifyAffiliationMutex.Lock()
 	ret, specificReturn := fake.modifyAffiliationReturnsOnCall[len(fake.modifyAffiliationArgsForCall)]
 	fake.modifyAffiliationArgsForCall = append(fake.modifyAffiliationArgsForCall, struct {
-		request *msp.ModifyAffiliationRequest
-	}{request})
-	fake.recordInvocation("ModifyAffiliation", []interface{}{request})
+		arg1 *msp.ModifyAffiliationRequest
+	}{arg1})
+	fake.recordInvocation("ModifyAffiliation", []interface{}{arg1})
 	fake.modifyAffiliationMutex.Unlock()
 	if fake.ModifyAffiliationStub != nil {
-		return fake.ModifyAffiliationStub(request)
+		return fake.ModifyAffiliationStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.modifyAffiliationReturns.result1, fake.modifyAffiliationReturns.result2
+	fakeReturns := fake.modifyAffiliationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) ModifyAffiliationCallCount() int {
@@ -758,13 +880,22 @@ func (fake *MSP) ModifyAffiliationCallCount() int {
 	return len(fake.modifyAffiliationArgsForCall)
 }
 
+func (fake *MSP) ModifyAffiliationCalls(stub func(*msp.ModifyAffiliationRequest) (*msp.AffiliationResponse, error)) {
+	fake.modifyAffiliationMutex.Lock()
+	defer fake.modifyAffiliationMutex.Unlock()
+	fake.ModifyAffiliationStub = stub
+}
+
 func (fake *MSP) ModifyAffiliationArgsForCall(i int) *msp.ModifyAffiliationRequest {
 	fake.modifyAffiliationMutex.RLock()
 	defer fake.modifyAffiliationMutex.RUnlock()
-	return fake.modifyAffiliationArgsForCall[i].request
+	argsForCall := fake.modifyAffiliationArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) ModifyAffiliationReturns(result1 *msp.AffiliationResponse, result2 error) {
+	fake.modifyAffiliationMutex.Lock()
+	defer fake.modifyAffiliationMutex.Unlock()
 	fake.ModifyAffiliationStub = nil
 	fake.modifyAffiliationReturns = struct {
 		result1 *msp.AffiliationResponse
@@ -773,6 +904,8 @@ func (fake *MSP) ModifyAffiliationReturns(result1 *msp.AffiliationResponse, resu
 }
 
 func (fake *MSP) ModifyAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResponse, result2 error) {
+	fake.modifyAffiliationMutex.Lock()
+	defer fake.modifyAffiliationMutex.Unlock()
 	fake.ModifyAffiliationStub = nil
 	if fake.modifyAffiliationReturnsOnCall == nil {
 		fake.modifyAffiliationReturnsOnCall = make(map[int]struct {
@@ -786,21 +919,22 @@ func (fake *MSP) ModifyAffiliationReturnsOnCall(i int, result1 *msp.AffiliationR
 	}{result1, result2}
 }
 
-func (fake *MSP) ModifyIdentity(request *msp.IdentityRequest) (*msp.IdentityResponse, error) {
+func (fake *MSP) ModifyIdentity(arg1 *msp.IdentityRequest) (*msp.IdentityResponse, error) {
 	fake.modifyIdentityMutex.Lock()
 	ret, specificReturn := fake.modifyIdentityReturnsOnCall[len(fake.modifyIdentityArgsForCall)]
 	fake.modifyIdentityArgsForCall = append(fake.modifyIdentityArgsForCall, struct {
-		request *msp.IdentityRequest
-	}{request})
-	fake.recordInvocation("ModifyIdentity", []interface{}{request})
+		arg1 *msp.IdentityRequest
+	}{arg1})
+	fake.recordInvocation("ModifyIdentity", []interface{}{arg1})
 	fake.modifyIdentityMutex.Unlock()
 	if fake.ModifyIdentityStub != nil {
-		return fake.ModifyIdentityStub(request)
+		return fake.ModifyIdentityStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.modifyIdentityReturns.result1, fake.modifyIdentityReturns.result2
+	fakeReturns := fake.modifyIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) ModifyIdentityCallCount() int {
@@ -809,13 +943,22 @@ func (fake *MSP) ModifyIdentityCallCount() int {
 	return len(fake.modifyIdentityArgsForCall)
 }
 
+func (fake *MSP) ModifyIdentityCalls(stub func(*msp.IdentityRequest) (*msp.IdentityResponse, error)) {
+	fake.modifyIdentityMutex.Lock()
+	defer fake.modifyIdentityMutex.Unlock()
+	fake.ModifyIdentityStub = stub
+}
+
 func (fake *MSP) ModifyIdentityArgsForCall(i int) *msp.IdentityRequest {
 	fake.modifyIdentityMutex.RLock()
 	defer fake.modifyIdentityMutex.RUnlock()
-	return fake.modifyIdentityArgsForCall[i].request
+	argsForCall := fake.modifyIdentityArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) ModifyIdentityReturns(result1 *msp.IdentityResponse, result2 error) {
+	fake.modifyIdentityMutex.Lock()
+	defer fake.modifyIdentityMutex.Unlock()
 	fake.ModifyIdentityStub = nil
 	fake.modifyIdentityReturns = struct {
 		result1 *msp.IdentityResponse
@@ -824,6 +967,8 @@ func (fake *MSP) ModifyIdentityReturns(result1 *msp.IdentityResponse, result2 er
 }
 
 func (fake *MSP) ModifyIdentityReturnsOnCall(i int, result1 *msp.IdentityResponse, result2 error) {
+	fake.modifyIdentityMutex.Lock()
+	defer fake.modifyIdentityMutex.Unlock()
 	fake.ModifyIdentityStub = nil
 	if fake.modifyIdentityReturnsOnCall == nil {
 		fake.modifyIdentityReturnsOnCall = make(map[int]struct {
@@ -837,22 +982,23 @@ func (fake *MSP) ModifyIdentityReturnsOnCall(i int, result1 *msp.IdentityRespons
 	}{result1, result2}
 }
 
-func (fake *MSP) Reenroll(enrollmentID string, opts ...msp.EnrollmentOption) error {
+func (fake *MSP) Reenroll(arg1 string, arg2 ...msp.EnrollmentOption) error {
 	fake.reenrollMutex.Lock()
 	ret, specificReturn := fake.reenrollReturnsOnCall[len(fake.reenrollArgsForCall)]
 	fake.reenrollArgsForCall = append(fake.reenrollArgsForCall, struct {
-		enrollmentID string
-		opts         []msp.EnrollmentOption
-	}{enrollmentID, opts})
-	fake.recordInvocation("Reenroll", []interface{}{enrollmentID, opts})
+		arg1 string
+		arg2 []msp.EnrollmentOption
+	}{arg1, arg2})
+	fake.recordInvocation("Reenroll", []interface{}{arg1, arg2})
 	fake.reenrollMutex.Unlock()
 	if fake.ReenrollStub != nil {
-		return fake.ReenrollStub(enrollmentID, opts...)
+		return fake.ReenrollStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.reenrollReturns.result1
+	fakeReturns := fake.reenrollReturns
+	return fakeReturns.result1
 }
 
 func (fake *MSP) ReenrollCallCount() int {
@@ -861,13 +1007,22 @@ func (fake *MSP) ReenrollCallCount() int {
 	return len(fake.reenrollArgsForCall)
 }
 
+func (fake *MSP) ReenrollCalls(stub func(string, ...msp.EnrollmentOption) error) {
+	fake.reenrollMutex.Lock()
+	defer fake.reenrollMutex.Unlock()
+	fake.ReenrollStub = stub
+}
+
 func (fake *MSP) ReenrollArgsForCall(i int) (string, []msp.EnrollmentOption) {
 	fake.reenrollMutex.RLock()
 	defer fake.reenrollMutex.RUnlock()
-	return fake.reenrollArgsForCall[i].enrollmentID, fake.reenrollArgsForCall[i].opts
+	argsForCall := fake.reenrollArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *MSP) ReenrollReturns(result1 error) {
+	fake.reenrollMutex.Lock()
+	defer fake.reenrollMutex.Unlock()
 	fake.ReenrollStub = nil
 	fake.reenrollReturns = struct {
 		result1 error
@@ -875,6 +1030,8 @@ func (fake *MSP) ReenrollReturns(result1 error) {
 }
 
 func (fake *MSP) ReenrollReturnsOnCall(i int, result1 error) {
+	fake.reenrollMutex.Lock()
+	defer fake.reenrollMutex.Unlock()
 	fake.ReenrollStub = nil
 	if fake.reenrollReturnsOnCall == nil {
 		fake.reenrollReturnsOnCall = make(map[int]struct {
@@ -886,21 +1043,22 @@ func (fake *MSP) ReenrollReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *MSP) Register(request *msp.RegistrationRequest) (string, error) {
+func (fake *MSP) Register(arg1 *msp.RegistrationRequest) (string, error) {
 	fake.registerMutex.Lock()
 	ret, specificReturn := fake.registerReturnsOnCall[len(fake.registerArgsForCall)]
 	fake.registerArgsForCall = append(fake.registerArgsForCall, struct {
-		request *msp.RegistrationRequest
-	}{request})
-	fake.recordInvocation("Register", []interface{}{request})
+		arg1 *msp.RegistrationRequest
+	}{arg1})
+	fake.recordInvocation("Register", []interface{}{arg1})
 	fake.registerMutex.Unlock()
 	if fake.RegisterStub != nil {
-		return fake.RegisterStub(request)
+		return fake.RegisterStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.registerReturns.result1, fake.registerReturns.result2
+	fakeReturns := fake.registerReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) RegisterCallCount() int {
@@ -909,13 +1067,22 @@ func (fake *MSP) RegisterCallCount() int {
 	return len(fake.registerArgsForCall)
 }
 
+func (fake *MSP) RegisterCalls(stub func(*msp.RegistrationRequest) (string, error)) {
+	fake.registerMutex.Lock()
+	defer fake.registerMutex.Unlock()
+	fake.RegisterStub = stub
+}
+
 func (fake *MSP) RegisterArgsForCall(i int) *msp.RegistrationRequest {
 	fake.registerMutex.RLock()
 	defer fake.registerMutex.RUnlock()
-	return fake.registerArgsForCall[i].request
+	argsForCall := fake.registerArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) RegisterReturns(result1 string, result2 error) {
+	fake.registerMutex.Lock()
+	defer fake.registerMutex.Unlock()
 	fake.RegisterStub = nil
 	fake.registerReturns = struct {
 		result1 string
@@ -924,6 +1091,8 @@ func (fake *MSP) RegisterReturns(result1 string, result2 error) {
 }
 
 func (fake *MSP) RegisterReturnsOnCall(i int, result1 string, result2 error) {
+	fake.registerMutex.Lock()
+	defer fake.registerMutex.Unlock()
 	fake.RegisterStub = nil
 	if fake.registerReturnsOnCall == nil {
 		fake.registerReturnsOnCall = make(map[int]struct {
@@ -937,21 +1106,22 @@ func (fake *MSP) RegisterReturnsOnCall(i int, result1 string, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *MSP) RemoveAffiliation(request *msp.AffiliationRequest) (*msp.AffiliationResponse, error) {
+func (fake *MSP) RemoveAffiliation(arg1 *msp.AffiliationRequest) (*msp.AffiliationResponse, error) {
 	fake.removeAffiliationMutex.Lock()
 	ret, specificReturn := fake.removeAffiliationReturnsOnCall[len(fake.removeAffiliationArgsForCall)]
 	fake.removeAffiliationArgsForCall = append(fake.removeAffiliationArgsForCall, struct {
-		request *msp.AffiliationRequest
-	}{request})
-	fake.recordInvocation("RemoveAffiliation", []interface{}{request})
+		arg1 *msp.AffiliationRequest
+	}{arg1})
+	fake.recordInvocation("RemoveAffiliation", []interface{}{arg1})
 	fake.removeAffiliationMutex.Unlock()
 	if fake.RemoveAffiliationStub != nil {
-		return fake.RemoveAffiliationStub(request)
+		return fake.RemoveAffiliationStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.removeAffiliationReturns.result1, fake.removeAffiliationReturns.result2
+	fakeReturns := fake.removeAffiliationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) RemoveAffiliationCallCount() int {
@@ -960,13 +1130,22 @@ func (fake *MSP) RemoveAffiliationCallCount() int {
 	return len(fake.removeAffiliationArgsForCall)
 }
 
+func (fake *MSP) RemoveAffiliationCalls(stub func(*msp.AffiliationRequest) (*msp.AffiliationResponse, error)) {
+	fake.removeAffiliationMutex.Lock()
+	defer fake.removeAffiliationMutex.Unlock()
+	fake.RemoveAffiliationStub = stub
+}
+
 func (fake *MSP) RemoveAffiliationArgsForCall(i int) *msp.AffiliationRequest {
 	fake.removeAffiliationMutex.RLock()
 	defer fake.removeAffiliationMutex.RUnlock()
-	return fake.removeAffiliationArgsForCall[i].request
+	argsForCall := fake.removeAffiliationArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) RemoveAffiliationReturns(result1 *msp.AffiliationResponse, result2 error) {
+	fake.removeAffiliationMutex.Lock()
+	defer fake.removeAffiliationMutex.Unlock()
 	fake.RemoveAffiliationStub = nil
 	fake.removeAffiliationReturns = struct {
 		result1 *msp.AffiliationResponse
@@ -975,6 +1154,8 @@ func (fake *MSP) RemoveAffiliationReturns(result1 *msp.AffiliationResponse, resu
 }
 
 func (fake *MSP) RemoveAffiliationReturnsOnCall(i int, result1 *msp.AffiliationResponse, result2 error) {
+	fake.removeAffiliationMutex.Lock()
+	defer fake.removeAffiliationMutex.Unlock()
 	fake.RemoveAffiliationStub = nil
 	if fake.removeAffiliationReturnsOnCall == nil {
 		fake.removeAffiliationReturnsOnCall = make(map[int]struct {
@@ -988,21 +1169,22 @@ func (fake *MSP) RemoveAffiliationReturnsOnCall(i int, result1 *msp.AffiliationR
 	}{result1, result2}
 }
 
-func (fake *MSP) RemoveIdentity(request *msp.RemoveIdentityRequest) (*msp.IdentityResponse, error) {
+func (fake *MSP) RemoveIdentity(arg1 *msp.RemoveIdentityRequest) (*msp.IdentityResponse, error) {
 	fake.removeIdentityMutex.Lock()
 	ret, specificReturn := fake.removeIdentityReturnsOnCall[len(fake.removeIdentityArgsForCall)]
 	fake.removeIdentityArgsForCall = append(fake.removeIdentityArgsForCall, struct {
-		request *msp.RemoveIdentityRequest
-	}{request})
-	fake.recordInvocation("RemoveIdentity", []interface{}{request})
+		arg1 *msp.RemoveIdentityRequest
+	}{arg1})
+	fake.recordInvocation("RemoveIdentity", []interface{}{arg1})
 	fake.removeIdentityMutex.Unlock()
 	if fake.RemoveIdentityStub != nil {
-		return fake.RemoveIdentityStub(request)
+		return fake.RemoveIdentityStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.removeIdentityReturns.result1, fake.removeIdentityReturns.result2
+	fakeReturns := fake.removeIdentityReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) RemoveIdentityCallCount() int {
@@ -1011,13 +1193,22 @@ func (fake *MSP) RemoveIdentityCallCount() int {
 	return len(fake.removeIdentityArgsForCall)
 }
 
+func (fake *MSP) RemoveIdentityCalls(stub func(*msp.RemoveIdentityRequest) (*msp.IdentityResponse, error)) {
+	fake.removeIdentityMutex.Lock()
+	defer fake.removeIdentityMutex.Unlock()
+	fake.RemoveIdentityStub = stub
+}
+
 func (fake *MSP) RemoveIdentityArgsForCall(i int) *msp.RemoveIdentityRequest {
 	fake.removeIdentityMutex.RLock()
 	defer fake.removeIdentityMutex.RUnlock()
-	return fake.removeIdentityArgsForCall[i].request
+	argsForCall := fake.removeIdentityArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) RemoveIdentityReturns(result1 *msp.IdentityResponse, result2 error) {
+	fake.removeIdentityMutex.Lock()
+	defer fake.removeIdentityMutex.Unlock()
 	fake.RemoveIdentityStub = nil
 	fake.removeIdentityReturns = struct {
 		result1 *msp.IdentityResponse
@@ -1026,6 +1217,8 @@ func (fake *MSP) RemoveIdentityReturns(result1 *msp.IdentityResponse, result2 er
 }
 
 func (fake *MSP) RemoveIdentityReturnsOnCall(i int, result1 *msp.IdentityResponse, result2 error) {
+	fake.removeIdentityMutex.Lock()
+	defer fake.removeIdentityMutex.Unlock()
 	fake.RemoveIdentityStub = nil
 	if fake.removeIdentityReturnsOnCall == nil {
 		fake.removeIdentityReturnsOnCall = make(map[int]struct {
@@ -1039,21 +1232,22 @@ func (fake *MSP) RemoveIdentityReturnsOnCall(i int, result1 *msp.IdentityRespons
 	}{result1, result2}
 }
 
-func (fake *MSP) Revoke(request *msp.RevocationRequest) (*msp.RevocationResponse, error) {
+func (fake *MSP) Revoke(arg1 *msp.RevocationRequest) (*msp.RevocationResponse, error) {
 	fake.revokeMutex.Lock()
 	ret, specificReturn := fake.revokeReturnsOnCall[len(fake.revokeArgsForCall)]
 	fake.revokeArgsForCall = append(fake.revokeArgsForCall, struct {
-		request *msp.RevocationRequest
-	}{request})
-	fake.recordInvocation("Revoke", []interface{}{request})
+		arg1 *msp.RevocationRequest
+	}{arg1})
+	fake.recordInvocation("Revoke", []interface{}{arg1})
 	fake.revokeMutex.Unlock()
 	if fake.RevokeStub != nil {
-		return fake.RevokeStub(request)
+		return fake.RevokeStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.revokeReturns.result1, fake.revokeReturns.result2
+	fakeReturns := fake.revokeReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *MSP) RevokeCallCount() int {
@@ -1062,13 +1256,22 @@ func (fake *MSP) RevokeCallCount() int {
 	return len(fake.revokeArgsForCall)
 }
 
+func (fake *MSP) RevokeCalls(stub func(*msp.RevocationRequest) (*msp.RevocationResponse, error)) {
+	fake.revokeMutex.Lock()
+	defer fake.revokeMutex.Unlock()
+	fake.RevokeStub = stub
+}
+
 func (fake *MSP) RevokeArgsForCall(i int) *msp.RevocationRequest {
 	fake.revokeMutex.RLock()
 	defer fake.revokeMutex.RUnlock()
-	return fake.revokeArgsForCall[i].request
+	argsForCall := fake.revokeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *MSP) RevokeReturns(result1 *msp.RevocationResponse, result2 error) {
+	fake.revokeMutex.Lock()
+	defer fake.revokeMutex.Unlock()
 	fake.RevokeStub = nil
 	fake.revokeReturns = struct {
 		result1 *msp.RevocationResponse
@@ -1077,6 +1280,8 @@ func (fake *MSP) RevokeReturns(result1 *msp.RevocationResponse, result2 error) {
 }
 
 func (fake *MSP) RevokeReturnsOnCall(i int, result1 *msp.RevocationResponse, result2 error) {
+	fake.revokeMutex.Lock()
+	defer fake.revokeMutex.Unlock()
 	fake.RevokeStub = nil
 	if fake.revokeReturnsOnCall == nil {
 		fake.revokeReturnsOnCall = make(map[int]struct {

--- a/pkg/fabric/mocks/resmgmt.go
+++ b/pkg/fabric/mocks/resmgmt.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/hyperledger/fabric-cli/pkg/fabric"
 	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
-	mspctx "github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fab/resource"
 )
 
 type ResourceManagement struct {
-	CreateConfigSignatureStub        func(signer mspctx.SigningIdentity, channelConfigPath string) (*common.ConfigSignature, error)
+	CreateConfigSignatureStub        func(msp.SigningIdentity, string) (*common.ConfigSignature, error)
 	createConfigSignatureMutex       sync.RWMutex
 	createConfigSignatureArgsForCall []struct {
-		signer            mspctx.SigningIdentity
-		channelConfigPath string
+		arg1 msp.SigningIdentity
+		arg2 string
 	}
 	createConfigSignatureReturns struct {
 		result1 *common.ConfigSignature
@@ -28,11 +28,11 @@ type ResourceManagement struct {
 		result1 *common.ConfigSignature
 		result2 error
 	}
-	CreateConfigSignatureDataStub        func(signer mspctx.SigningIdentity, channelConfigPath string) (signatureHeaderData resource.ConfigSignatureData, e error)
+	CreateConfigSignatureDataStub        func(msp.SigningIdentity, string) (resource.ConfigSignatureData, error)
 	createConfigSignatureDataMutex       sync.RWMutex
 	createConfigSignatureDataArgsForCall []struct {
-		signer            mspctx.SigningIdentity
-		channelConfigPath string
+		arg1 msp.SigningIdentity
+		arg2 string
 	}
 	createConfigSignatureDataReturns struct {
 		result1 resource.ConfigSignatureData
@@ -42,11 +42,11 @@ type ResourceManagement struct {
 		result1 resource.ConfigSignatureData
 		result2 error
 	}
-	InstallCCStub        func(req resmgmt.InstallCCRequest, options ...resmgmt.RequestOption) ([]resmgmt.InstallCCResponse, error)
+	InstallCCStub        func(resmgmt.InstallCCRequest, ...resmgmt.RequestOption) ([]resmgmt.InstallCCResponse, error)
 	installCCMutex       sync.RWMutex
 	installCCArgsForCall []struct {
-		req     resmgmt.InstallCCRequest
-		options []resmgmt.RequestOption
+		arg1 resmgmt.InstallCCRequest
+		arg2 []resmgmt.RequestOption
 	}
 	installCCReturns struct {
 		result1 []resmgmt.InstallCCResponse
@@ -56,12 +56,12 @@ type ResourceManagement struct {
 		result1 []resmgmt.InstallCCResponse
 		result2 error
 	}
-	InstantiateCCStub        func(channelID string, req resmgmt.InstantiateCCRequest, options ...resmgmt.RequestOption) (resmgmt.InstantiateCCResponse, error)
+	InstantiateCCStub        func(string, resmgmt.InstantiateCCRequest, ...resmgmt.RequestOption) (resmgmt.InstantiateCCResponse, error)
 	instantiateCCMutex       sync.RWMutex
 	instantiateCCArgsForCall []struct {
-		channelID string
-		req       resmgmt.InstantiateCCRequest
-		options   []resmgmt.RequestOption
+		arg1 string
+		arg2 resmgmt.InstantiateCCRequest
+		arg3 []resmgmt.RequestOption
 	}
 	instantiateCCReturns struct {
 		result1 resmgmt.InstantiateCCResponse
@@ -71,11 +71,11 @@ type ResourceManagement struct {
 		result1 resmgmt.InstantiateCCResponse
 		result2 error
 	}
-	JoinChannelStub        func(channelID string, options ...resmgmt.RequestOption) error
+	JoinChannelStub        func(string, ...resmgmt.RequestOption) error
 	joinChannelMutex       sync.RWMutex
 	joinChannelArgsForCall []struct {
-		channelID string
-		options   []resmgmt.RequestOption
+		arg1 string
+		arg2 []resmgmt.RequestOption
 	}
 	joinChannelReturns struct {
 		result1 error
@@ -83,25 +83,25 @@ type ResourceManagement struct {
 	joinChannelReturnsOnCall map[int]struct {
 		result1 error
 	}
-	QueryChannelsStub        func(options ...resmgmt.RequestOption) (*pb.ChannelQueryResponse, error)
+	QueryChannelsStub        func(...resmgmt.RequestOption) (*peer.ChannelQueryResponse, error)
 	queryChannelsMutex       sync.RWMutex
 	queryChannelsArgsForCall []struct {
-		options []resmgmt.RequestOption
+		arg1 []resmgmt.RequestOption
 	}
 	queryChannelsReturns struct {
-		result1 *pb.ChannelQueryResponse
+		result1 *peer.ChannelQueryResponse
 		result2 error
 	}
 	queryChannelsReturnsOnCall map[int]struct {
-		result1 *pb.ChannelQueryResponse
+		result1 *peer.ChannelQueryResponse
 		result2 error
 	}
-	QueryCollectionsConfigStub        func(channelID string, chaincodeName string, options ...resmgmt.RequestOption) (*common.CollectionConfigPackage, error)
+	QueryCollectionsConfigStub        func(string, string, ...resmgmt.RequestOption) (*common.CollectionConfigPackage, error)
 	queryCollectionsConfigMutex       sync.RWMutex
 	queryCollectionsConfigArgsForCall []struct {
-		channelID     string
-		chaincodeName string
-		options       []resmgmt.RequestOption
+		arg1 string
+		arg2 string
+		arg3 []resmgmt.RequestOption
 	}
 	queryCollectionsConfigReturns struct {
 		result1 *common.CollectionConfigPackage
@@ -111,11 +111,11 @@ type ResourceManagement struct {
 		result1 *common.CollectionConfigPackage
 		result2 error
 	}
-	QueryConfigFromOrdererStub        func(channelID string, options ...resmgmt.RequestOption) (fab.ChannelCfg, error)
+	QueryConfigFromOrdererStub        func(string, ...resmgmt.RequestOption) (fab.ChannelCfg, error)
 	queryConfigFromOrdererMutex       sync.RWMutex
 	queryConfigFromOrdererArgsForCall []struct {
-		channelID string
-		options   []resmgmt.RequestOption
+		arg1 string
+		arg2 []resmgmt.RequestOption
 	}
 	queryConfigFromOrdererReturns struct {
 		result1 fab.ChannelCfg
@@ -125,38 +125,38 @@ type ResourceManagement struct {
 		result1 fab.ChannelCfg
 		result2 error
 	}
-	QueryInstalledChaincodesStub        func(options ...resmgmt.RequestOption) (*pb.ChaincodeQueryResponse, error)
+	QueryInstalledChaincodesStub        func(...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error)
 	queryInstalledChaincodesMutex       sync.RWMutex
 	queryInstalledChaincodesArgsForCall []struct {
-		options []resmgmt.RequestOption
+		arg1 []resmgmt.RequestOption
 	}
 	queryInstalledChaincodesReturns struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}
 	queryInstalledChaincodesReturnsOnCall map[int]struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}
-	QueryInstantiatedChaincodesStub        func(channelID string, options ...resmgmt.RequestOption) (*pb.ChaincodeQueryResponse, error)
+	QueryInstantiatedChaincodesStub        func(string, ...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error)
 	queryInstantiatedChaincodesMutex       sync.RWMutex
 	queryInstantiatedChaincodesArgsForCall []struct {
-		channelID string
-		options   []resmgmt.RequestOption
+		arg1 string
+		arg2 []resmgmt.RequestOption
 	}
 	queryInstantiatedChaincodesReturns struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}
 	queryInstantiatedChaincodesReturnsOnCall map[int]struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}
-	SaveChannelStub        func(req resmgmt.SaveChannelRequest, options ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error)
+	SaveChannelStub        func(resmgmt.SaveChannelRequest, ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error)
 	saveChannelMutex       sync.RWMutex
 	saveChannelArgsForCall []struct {
-		req     resmgmt.SaveChannelRequest
-		options []resmgmt.RequestOption
+		arg1 resmgmt.SaveChannelRequest
+		arg2 []resmgmt.RequestOption
 	}
 	saveChannelReturns struct {
 		result1 resmgmt.SaveChannelResponse
@@ -166,12 +166,12 @@ type ResourceManagement struct {
 		result1 resmgmt.SaveChannelResponse
 		result2 error
 	}
-	UpgradeCCStub        func(channelID string, req resmgmt.UpgradeCCRequest, options ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error)
+	UpgradeCCStub        func(string, resmgmt.UpgradeCCRequest, ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error)
 	upgradeCCMutex       sync.RWMutex
 	upgradeCCArgsForCall []struct {
-		channelID string
-		req       resmgmt.UpgradeCCRequest
-		options   []resmgmt.RequestOption
+		arg1 string
+		arg2 resmgmt.UpgradeCCRequest
+		arg3 []resmgmt.RequestOption
 	}
 	upgradeCCReturns struct {
 		result1 resmgmt.UpgradeCCResponse
@@ -185,22 +185,23 @@ type ResourceManagement struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ResourceManagement) CreateConfigSignature(signer mspctx.SigningIdentity, channelConfigPath string) (*common.ConfigSignature, error) {
+func (fake *ResourceManagement) CreateConfigSignature(arg1 msp.SigningIdentity, arg2 string) (*common.ConfigSignature, error) {
 	fake.createConfigSignatureMutex.Lock()
 	ret, specificReturn := fake.createConfigSignatureReturnsOnCall[len(fake.createConfigSignatureArgsForCall)]
 	fake.createConfigSignatureArgsForCall = append(fake.createConfigSignatureArgsForCall, struct {
-		signer            mspctx.SigningIdentity
-		channelConfigPath string
-	}{signer, channelConfigPath})
-	fake.recordInvocation("CreateConfigSignature", []interface{}{signer, channelConfigPath})
+		arg1 msp.SigningIdentity
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("CreateConfigSignature", []interface{}{arg1, arg2})
 	fake.createConfigSignatureMutex.Unlock()
 	if fake.CreateConfigSignatureStub != nil {
-		return fake.CreateConfigSignatureStub(signer, channelConfigPath)
+		return fake.CreateConfigSignatureStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createConfigSignatureReturns.result1, fake.createConfigSignatureReturns.result2
+	fakeReturns := fake.createConfigSignatureReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureCallCount() int {
@@ -209,13 +210,22 @@ func (fake *ResourceManagement) CreateConfigSignatureCallCount() int {
 	return len(fake.createConfigSignatureArgsForCall)
 }
 
-func (fake *ResourceManagement) CreateConfigSignatureArgsForCall(i int) (mspctx.SigningIdentity, string) {
+func (fake *ResourceManagement) CreateConfigSignatureCalls(stub func(msp.SigningIdentity, string) (*common.ConfigSignature, error)) {
+	fake.createConfigSignatureMutex.Lock()
+	defer fake.createConfigSignatureMutex.Unlock()
+	fake.CreateConfigSignatureStub = stub
+}
+
+func (fake *ResourceManagement) CreateConfigSignatureArgsForCall(i int) (msp.SigningIdentity, string) {
 	fake.createConfigSignatureMutex.RLock()
 	defer fake.createConfigSignatureMutex.RUnlock()
-	return fake.createConfigSignatureArgsForCall[i].signer, fake.createConfigSignatureArgsForCall[i].channelConfigPath
+	argsForCall := fake.createConfigSignatureArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureReturns(result1 *common.ConfigSignature, result2 error) {
+	fake.createConfigSignatureMutex.Lock()
+	defer fake.createConfigSignatureMutex.Unlock()
 	fake.CreateConfigSignatureStub = nil
 	fake.createConfigSignatureReturns = struct {
 		result1 *common.ConfigSignature
@@ -224,6 +234,8 @@ func (fake *ResourceManagement) CreateConfigSignatureReturns(result1 *common.Con
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureReturnsOnCall(i int, result1 *common.ConfigSignature, result2 error) {
+	fake.createConfigSignatureMutex.Lock()
+	defer fake.createConfigSignatureMutex.Unlock()
 	fake.CreateConfigSignatureStub = nil
 	if fake.createConfigSignatureReturnsOnCall == nil {
 		fake.createConfigSignatureReturnsOnCall = make(map[int]struct {
@@ -237,22 +249,23 @@ func (fake *ResourceManagement) CreateConfigSignatureReturnsOnCall(i int, result
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) CreateConfigSignatureData(signer mspctx.SigningIdentity, channelConfigPath string) (signatureHeaderData resource.ConfigSignatureData, e error) {
+func (fake *ResourceManagement) CreateConfigSignatureData(arg1 msp.SigningIdentity, arg2 string) (resource.ConfigSignatureData, error) {
 	fake.createConfigSignatureDataMutex.Lock()
 	ret, specificReturn := fake.createConfigSignatureDataReturnsOnCall[len(fake.createConfigSignatureDataArgsForCall)]
 	fake.createConfigSignatureDataArgsForCall = append(fake.createConfigSignatureDataArgsForCall, struct {
-		signer            mspctx.SigningIdentity
-		channelConfigPath string
-	}{signer, channelConfigPath})
-	fake.recordInvocation("CreateConfigSignatureData", []interface{}{signer, channelConfigPath})
+		arg1 msp.SigningIdentity
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("CreateConfigSignatureData", []interface{}{arg1, arg2})
 	fake.createConfigSignatureDataMutex.Unlock()
 	if fake.CreateConfigSignatureDataStub != nil {
-		return fake.CreateConfigSignatureDataStub(signer, channelConfigPath)
+		return fake.CreateConfigSignatureDataStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createConfigSignatureDataReturns.result1, fake.createConfigSignatureDataReturns.result2
+	fakeReturns := fake.createConfigSignatureDataReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureDataCallCount() int {
@@ -261,13 +274,22 @@ func (fake *ResourceManagement) CreateConfigSignatureDataCallCount() int {
 	return len(fake.createConfigSignatureDataArgsForCall)
 }
 
-func (fake *ResourceManagement) CreateConfigSignatureDataArgsForCall(i int) (mspctx.SigningIdentity, string) {
+func (fake *ResourceManagement) CreateConfigSignatureDataCalls(stub func(msp.SigningIdentity, string) (resource.ConfigSignatureData, error)) {
+	fake.createConfigSignatureDataMutex.Lock()
+	defer fake.createConfigSignatureDataMutex.Unlock()
+	fake.CreateConfigSignatureDataStub = stub
+}
+
+func (fake *ResourceManagement) CreateConfigSignatureDataArgsForCall(i int) (msp.SigningIdentity, string) {
 	fake.createConfigSignatureDataMutex.RLock()
 	defer fake.createConfigSignatureDataMutex.RUnlock()
-	return fake.createConfigSignatureDataArgsForCall[i].signer, fake.createConfigSignatureDataArgsForCall[i].channelConfigPath
+	argsForCall := fake.createConfigSignatureDataArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureDataReturns(result1 resource.ConfigSignatureData, result2 error) {
+	fake.createConfigSignatureDataMutex.Lock()
+	defer fake.createConfigSignatureDataMutex.Unlock()
 	fake.CreateConfigSignatureDataStub = nil
 	fake.createConfigSignatureDataReturns = struct {
 		result1 resource.ConfigSignatureData
@@ -276,6 +298,8 @@ func (fake *ResourceManagement) CreateConfigSignatureDataReturns(result1 resourc
 }
 
 func (fake *ResourceManagement) CreateConfigSignatureDataReturnsOnCall(i int, result1 resource.ConfigSignatureData, result2 error) {
+	fake.createConfigSignatureDataMutex.Lock()
+	defer fake.createConfigSignatureDataMutex.Unlock()
 	fake.CreateConfigSignatureDataStub = nil
 	if fake.createConfigSignatureDataReturnsOnCall == nil {
 		fake.createConfigSignatureDataReturnsOnCall = make(map[int]struct {
@@ -289,22 +313,23 @@ func (fake *ResourceManagement) CreateConfigSignatureDataReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) InstallCC(req resmgmt.InstallCCRequest, options ...resmgmt.RequestOption) ([]resmgmt.InstallCCResponse, error) {
+func (fake *ResourceManagement) InstallCC(arg1 resmgmt.InstallCCRequest, arg2 ...resmgmt.RequestOption) ([]resmgmt.InstallCCResponse, error) {
 	fake.installCCMutex.Lock()
 	ret, specificReturn := fake.installCCReturnsOnCall[len(fake.installCCArgsForCall)]
 	fake.installCCArgsForCall = append(fake.installCCArgsForCall, struct {
-		req     resmgmt.InstallCCRequest
-		options []resmgmt.RequestOption
-	}{req, options})
-	fake.recordInvocation("InstallCC", []interface{}{req, options})
+		arg1 resmgmt.InstallCCRequest
+		arg2 []resmgmt.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("InstallCC", []interface{}{arg1, arg2})
 	fake.installCCMutex.Unlock()
 	if fake.InstallCCStub != nil {
-		return fake.InstallCCStub(req, options...)
+		return fake.InstallCCStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.installCCReturns.result1, fake.installCCReturns.result2
+	fakeReturns := fake.installCCReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) InstallCCCallCount() int {
@@ -313,13 +338,22 @@ func (fake *ResourceManagement) InstallCCCallCount() int {
 	return len(fake.installCCArgsForCall)
 }
 
+func (fake *ResourceManagement) InstallCCCalls(stub func(resmgmt.InstallCCRequest, ...resmgmt.RequestOption) ([]resmgmt.InstallCCResponse, error)) {
+	fake.installCCMutex.Lock()
+	defer fake.installCCMutex.Unlock()
+	fake.InstallCCStub = stub
+}
+
 func (fake *ResourceManagement) InstallCCArgsForCall(i int) (resmgmt.InstallCCRequest, []resmgmt.RequestOption) {
 	fake.installCCMutex.RLock()
 	defer fake.installCCMutex.RUnlock()
-	return fake.installCCArgsForCall[i].req, fake.installCCArgsForCall[i].options
+	argsForCall := fake.installCCArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) InstallCCReturns(result1 []resmgmt.InstallCCResponse, result2 error) {
+	fake.installCCMutex.Lock()
+	defer fake.installCCMutex.Unlock()
 	fake.InstallCCStub = nil
 	fake.installCCReturns = struct {
 		result1 []resmgmt.InstallCCResponse
@@ -328,6 +362,8 @@ func (fake *ResourceManagement) InstallCCReturns(result1 []resmgmt.InstallCCResp
 }
 
 func (fake *ResourceManagement) InstallCCReturnsOnCall(i int, result1 []resmgmt.InstallCCResponse, result2 error) {
+	fake.installCCMutex.Lock()
+	defer fake.installCCMutex.Unlock()
 	fake.InstallCCStub = nil
 	if fake.installCCReturnsOnCall == nil {
 		fake.installCCReturnsOnCall = make(map[int]struct {
@@ -341,23 +377,24 @@ func (fake *ResourceManagement) InstallCCReturnsOnCall(i int, result1 []resmgmt.
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) InstantiateCC(channelID string, req resmgmt.InstantiateCCRequest, options ...resmgmt.RequestOption) (resmgmt.InstantiateCCResponse, error) {
+func (fake *ResourceManagement) InstantiateCC(arg1 string, arg2 resmgmt.InstantiateCCRequest, arg3 ...resmgmt.RequestOption) (resmgmt.InstantiateCCResponse, error) {
 	fake.instantiateCCMutex.Lock()
 	ret, specificReturn := fake.instantiateCCReturnsOnCall[len(fake.instantiateCCArgsForCall)]
 	fake.instantiateCCArgsForCall = append(fake.instantiateCCArgsForCall, struct {
-		channelID string
-		req       resmgmt.InstantiateCCRequest
-		options   []resmgmt.RequestOption
-	}{channelID, req, options})
-	fake.recordInvocation("InstantiateCC", []interface{}{channelID, req, options})
+		arg1 string
+		arg2 resmgmt.InstantiateCCRequest
+		arg3 []resmgmt.RequestOption
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("InstantiateCC", []interface{}{arg1, arg2, arg3})
 	fake.instantiateCCMutex.Unlock()
 	if fake.InstantiateCCStub != nil {
-		return fake.InstantiateCCStub(channelID, req, options...)
+		return fake.InstantiateCCStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.instantiateCCReturns.result1, fake.instantiateCCReturns.result2
+	fakeReturns := fake.instantiateCCReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) InstantiateCCCallCount() int {
@@ -366,13 +403,22 @@ func (fake *ResourceManagement) InstantiateCCCallCount() int {
 	return len(fake.instantiateCCArgsForCall)
 }
 
+func (fake *ResourceManagement) InstantiateCCCalls(stub func(string, resmgmt.InstantiateCCRequest, ...resmgmt.RequestOption) (resmgmt.InstantiateCCResponse, error)) {
+	fake.instantiateCCMutex.Lock()
+	defer fake.instantiateCCMutex.Unlock()
+	fake.InstantiateCCStub = stub
+}
+
 func (fake *ResourceManagement) InstantiateCCArgsForCall(i int) (string, resmgmt.InstantiateCCRequest, []resmgmt.RequestOption) {
 	fake.instantiateCCMutex.RLock()
 	defer fake.instantiateCCMutex.RUnlock()
-	return fake.instantiateCCArgsForCall[i].channelID, fake.instantiateCCArgsForCall[i].req, fake.instantiateCCArgsForCall[i].options
+	argsForCall := fake.instantiateCCArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ResourceManagement) InstantiateCCReturns(result1 resmgmt.InstantiateCCResponse, result2 error) {
+	fake.instantiateCCMutex.Lock()
+	defer fake.instantiateCCMutex.Unlock()
 	fake.InstantiateCCStub = nil
 	fake.instantiateCCReturns = struct {
 		result1 resmgmt.InstantiateCCResponse
@@ -381,6 +427,8 @@ func (fake *ResourceManagement) InstantiateCCReturns(result1 resmgmt.Instantiate
 }
 
 func (fake *ResourceManagement) InstantiateCCReturnsOnCall(i int, result1 resmgmt.InstantiateCCResponse, result2 error) {
+	fake.instantiateCCMutex.Lock()
+	defer fake.instantiateCCMutex.Unlock()
 	fake.InstantiateCCStub = nil
 	if fake.instantiateCCReturnsOnCall == nil {
 		fake.instantiateCCReturnsOnCall = make(map[int]struct {
@@ -394,22 +442,23 @@ func (fake *ResourceManagement) InstantiateCCReturnsOnCall(i int, result1 resmgm
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) JoinChannel(channelID string, options ...resmgmt.RequestOption) error {
+func (fake *ResourceManagement) JoinChannel(arg1 string, arg2 ...resmgmt.RequestOption) error {
 	fake.joinChannelMutex.Lock()
 	ret, specificReturn := fake.joinChannelReturnsOnCall[len(fake.joinChannelArgsForCall)]
 	fake.joinChannelArgsForCall = append(fake.joinChannelArgsForCall, struct {
-		channelID string
-		options   []resmgmt.RequestOption
-	}{channelID, options})
-	fake.recordInvocation("JoinChannel", []interface{}{channelID, options})
+		arg1 string
+		arg2 []resmgmt.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("JoinChannel", []interface{}{arg1, arg2})
 	fake.joinChannelMutex.Unlock()
 	if fake.JoinChannelStub != nil {
-		return fake.JoinChannelStub(channelID, options...)
+		return fake.JoinChannelStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.joinChannelReturns.result1
+	fakeReturns := fake.joinChannelReturns
+	return fakeReturns.result1
 }
 
 func (fake *ResourceManagement) JoinChannelCallCount() int {
@@ -418,13 +467,22 @@ func (fake *ResourceManagement) JoinChannelCallCount() int {
 	return len(fake.joinChannelArgsForCall)
 }
 
+func (fake *ResourceManagement) JoinChannelCalls(stub func(string, ...resmgmt.RequestOption) error) {
+	fake.joinChannelMutex.Lock()
+	defer fake.joinChannelMutex.Unlock()
+	fake.JoinChannelStub = stub
+}
+
 func (fake *ResourceManagement) JoinChannelArgsForCall(i int) (string, []resmgmt.RequestOption) {
 	fake.joinChannelMutex.RLock()
 	defer fake.joinChannelMutex.RUnlock()
-	return fake.joinChannelArgsForCall[i].channelID, fake.joinChannelArgsForCall[i].options
+	argsForCall := fake.joinChannelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) JoinChannelReturns(result1 error) {
+	fake.joinChannelMutex.Lock()
+	defer fake.joinChannelMutex.Unlock()
 	fake.JoinChannelStub = nil
 	fake.joinChannelReturns = struct {
 		result1 error
@@ -432,6 +490,8 @@ func (fake *ResourceManagement) JoinChannelReturns(result1 error) {
 }
 
 func (fake *ResourceManagement) JoinChannelReturnsOnCall(i int, result1 error) {
+	fake.joinChannelMutex.Lock()
+	defer fake.joinChannelMutex.Unlock()
 	fake.JoinChannelStub = nil
 	if fake.joinChannelReturnsOnCall == nil {
 		fake.joinChannelReturnsOnCall = make(map[int]struct {
@@ -443,21 +503,22 @@ func (fake *ResourceManagement) JoinChannelReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ResourceManagement) QueryChannels(options ...resmgmt.RequestOption) (*pb.ChannelQueryResponse, error) {
+func (fake *ResourceManagement) QueryChannels(arg1 ...resmgmt.RequestOption) (*peer.ChannelQueryResponse, error) {
 	fake.queryChannelsMutex.Lock()
 	ret, specificReturn := fake.queryChannelsReturnsOnCall[len(fake.queryChannelsArgsForCall)]
 	fake.queryChannelsArgsForCall = append(fake.queryChannelsArgsForCall, struct {
-		options []resmgmt.RequestOption
-	}{options})
-	fake.recordInvocation("QueryChannels", []interface{}{options})
+		arg1 []resmgmt.RequestOption
+	}{arg1})
+	fake.recordInvocation("QueryChannels", []interface{}{arg1})
 	fake.queryChannelsMutex.Unlock()
 	if fake.QueryChannelsStub != nil {
-		return fake.QueryChannelsStub(options...)
+		return fake.QueryChannelsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryChannelsReturns.result1, fake.queryChannelsReturns.result2
+	fakeReturns := fake.queryChannelsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) QueryChannelsCallCount() int {
@@ -466,51 +527,63 @@ func (fake *ResourceManagement) QueryChannelsCallCount() int {
 	return len(fake.queryChannelsArgsForCall)
 }
 
+func (fake *ResourceManagement) QueryChannelsCalls(stub func(...resmgmt.RequestOption) (*peer.ChannelQueryResponse, error)) {
+	fake.queryChannelsMutex.Lock()
+	defer fake.queryChannelsMutex.Unlock()
+	fake.QueryChannelsStub = stub
+}
+
 func (fake *ResourceManagement) QueryChannelsArgsForCall(i int) []resmgmt.RequestOption {
 	fake.queryChannelsMutex.RLock()
 	defer fake.queryChannelsMutex.RUnlock()
-	return fake.queryChannelsArgsForCall[i].options
+	argsForCall := fake.queryChannelsArgsForCall[i]
+	return argsForCall.arg1
 }
 
-func (fake *ResourceManagement) QueryChannelsReturns(result1 *pb.ChannelQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryChannelsReturns(result1 *peer.ChannelQueryResponse, result2 error) {
+	fake.queryChannelsMutex.Lock()
+	defer fake.queryChannelsMutex.Unlock()
 	fake.QueryChannelsStub = nil
 	fake.queryChannelsReturns = struct {
-		result1 *pb.ChannelQueryResponse
+		result1 *peer.ChannelQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryChannelsReturnsOnCall(i int, result1 *pb.ChannelQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryChannelsReturnsOnCall(i int, result1 *peer.ChannelQueryResponse, result2 error) {
+	fake.queryChannelsMutex.Lock()
+	defer fake.queryChannelsMutex.Unlock()
 	fake.QueryChannelsStub = nil
 	if fake.queryChannelsReturnsOnCall == nil {
 		fake.queryChannelsReturnsOnCall = make(map[int]struct {
-			result1 *pb.ChannelQueryResponse
+			result1 *peer.ChannelQueryResponse
 			result2 error
 		})
 	}
 	fake.queryChannelsReturnsOnCall[i] = struct {
-		result1 *pb.ChannelQueryResponse
+		result1 *peer.ChannelQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryCollectionsConfig(channelID string, chaincodeName string, options ...resmgmt.RequestOption) (*common.CollectionConfigPackage, error) {
+func (fake *ResourceManagement) QueryCollectionsConfig(arg1 string, arg2 string, arg3 ...resmgmt.RequestOption) (*common.CollectionConfigPackage, error) {
 	fake.queryCollectionsConfigMutex.Lock()
 	ret, specificReturn := fake.queryCollectionsConfigReturnsOnCall[len(fake.queryCollectionsConfigArgsForCall)]
 	fake.queryCollectionsConfigArgsForCall = append(fake.queryCollectionsConfigArgsForCall, struct {
-		channelID     string
-		chaincodeName string
-		options       []resmgmt.RequestOption
-	}{channelID, chaincodeName, options})
-	fake.recordInvocation("QueryCollectionsConfig", []interface{}{channelID, chaincodeName, options})
+		arg1 string
+		arg2 string
+		arg3 []resmgmt.RequestOption
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("QueryCollectionsConfig", []interface{}{arg1, arg2, arg3})
 	fake.queryCollectionsConfigMutex.Unlock()
 	if fake.QueryCollectionsConfigStub != nil {
-		return fake.QueryCollectionsConfigStub(channelID, chaincodeName, options...)
+		return fake.QueryCollectionsConfigStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryCollectionsConfigReturns.result1, fake.queryCollectionsConfigReturns.result2
+	fakeReturns := fake.queryCollectionsConfigReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) QueryCollectionsConfigCallCount() int {
@@ -519,13 +592,22 @@ func (fake *ResourceManagement) QueryCollectionsConfigCallCount() int {
 	return len(fake.queryCollectionsConfigArgsForCall)
 }
 
+func (fake *ResourceManagement) QueryCollectionsConfigCalls(stub func(string, string, ...resmgmt.RequestOption) (*common.CollectionConfigPackage, error)) {
+	fake.queryCollectionsConfigMutex.Lock()
+	defer fake.queryCollectionsConfigMutex.Unlock()
+	fake.QueryCollectionsConfigStub = stub
+}
+
 func (fake *ResourceManagement) QueryCollectionsConfigArgsForCall(i int) (string, string, []resmgmt.RequestOption) {
 	fake.queryCollectionsConfigMutex.RLock()
 	defer fake.queryCollectionsConfigMutex.RUnlock()
-	return fake.queryCollectionsConfigArgsForCall[i].channelID, fake.queryCollectionsConfigArgsForCall[i].chaincodeName, fake.queryCollectionsConfigArgsForCall[i].options
+	argsForCall := fake.queryCollectionsConfigArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ResourceManagement) QueryCollectionsConfigReturns(result1 *common.CollectionConfigPackage, result2 error) {
+	fake.queryCollectionsConfigMutex.Lock()
+	defer fake.queryCollectionsConfigMutex.Unlock()
 	fake.QueryCollectionsConfigStub = nil
 	fake.queryCollectionsConfigReturns = struct {
 		result1 *common.CollectionConfigPackage
@@ -534,6 +616,8 @@ func (fake *ResourceManagement) QueryCollectionsConfigReturns(result1 *common.Co
 }
 
 func (fake *ResourceManagement) QueryCollectionsConfigReturnsOnCall(i int, result1 *common.CollectionConfigPackage, result2 error) {
+	fake.queryCollectionsConfigMutex.Lock()
+	defer fake.queryCollectionsConfigMutex.Unlock()
 	fake.QueryCollectionsConfigStub = nil
 	if fake.queryCollectionsConfigReturnsOnCall == nil {
 		fake.queryCollectionsConfigReturnsOnCall = make(map[int]struct {
@@ -547,22 +631,23 @@ func (fake *ResourceManagement) QueryCollectionsConfigReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryConfigFromOrderer(channelID string, options ...resmgmt.RequestOption) (fab.ChannelCfg, error) {
+func (fake *ResourceManagement) QueryConfigFromOrderer(arg1 string, arg2 ...resmgmt.RequestOption) (fab.ChannelCfg, error) {
 	fake.queryConfigFromOrdererMutex.Lock()
 	ret, specificReturn := fake.queryConfigFromOrdererReturnsOnCall[len(fake.queryConfigFromOrdererArgsForCall)]
 	fake.queryConfigFromOrdererArgsForCall = append(fake.queryConfigFromOrdererArgsForCall, struct {
-		channelID string
-		options   []resmgmt.RequestOption
-	}{channelID, options})
-	fake.recordInvocation("QueryConfigFromOrderer", []interface{}{channelID, options})
+		arg1 string
+		arg2 []resmgmt.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("QueryConfigFromOrderer", []interface{}{arg1, arg2})
 	fake.queryConfigFromOrdererMutex.Unlock()
 	if fake.QueryConfigFromOrdererStub != nil {
-		return fake.QueryConfigFromOrdererStub(channelID, options...)
+		return fake.QueryConfigFromOrdererStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryConfigFromOrdererReturns.result1, fake.queryConfigFromOrdererReturns.result2
+	fakeReturns := fake.queryConfigFromOrdererReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) QueryConfigFromOrdererCallCount() int {
@@ -571,13 +656,22 @@ func (fake *ResourceManagement) QueryConfigFromOrdererCallCount() int {
 	return len(fake.queryConfigFromOrdererArgsForCall)
 }
 
+func (fake *ResourceManagement) QueryConfigFromOrdererCalls(stub func(string, ...resmgmt.RequestOption) (fab.ChannelCfg, error)) {
+	fake.queryConfigFromOrdererMutex.Lock()
+	defer fake.queryConfigFromOrdererMutex.Unlock()
+	fake.QueryConfigFromOrdererStub = stub
+}
+
 func (fake *ResourceManagement) QueryConfigFromOrdererArgsForCall(i int) (string, []resmgmt.RequestOption) {
 	fake.queryConfigFromOrdererMutex.RLock()
 	defer fake.queryConfigFromOrdererMutex.RUnlock()
-	return fake.queryConfigFromOrdererArgsForCall[i].channelID, fake.queryConfigFromOrdererArgsForCall[i].options
+	argsForCall := fake.queryConfigFromOrdererArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) QueryConfigFromOrdererReturns(result1 fab.ChannelCfg, result2 error) {
+	fake.queryConfigFromOrdererMutex.Lock()
+	defer fake.queryConfigFromOrdererMutex.Unlock()
 	fake.QueryConfigFromOrdererStub = nil
 	fake.queryConfigFromOrdererReturns = struct {
 		result1 fab.ChannelCfg
@@ -586,6 +680,8 @@ func (fake *ResourceManagement) QueryConfigFromOrdererReturns(result1 fab.Channe
 }
 
 func (fake *ResourceManagement) QueryConfigFromOrdererReturnsOnCall(i int, result1 fab.ChannelCfg, result2 error) {
+	fake.queryConfigFromOrdererMutex.Lock()
+	defer fake.queryConfigFromOrdererMutex.Unlock()
 	fake.QueryConfigFromOrdererStub = nil
 	if fake.queryConfigFromOrdererReturnsOnCall == nil {
 		fake.queryConfigFromOrdererReturnsOnCall = make(map[int]struct {
@@ -599,21 +695,22 @@ func (fake *ResourceManagement) QueryConfigFromOrdererReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryInstalledChaincodes(options ...resmgmt.RequestOption) (*pb.ChaincodeQueryResponse, error) {
+func (fake *ResourceManagement) QueryInstalledChaincodes(arg1 ...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error) {
 	fake.queryInstalledChaincodesMutex.Lock()
 	ret, specificReturn := fake.queryInstalledChaincodesReturnsOnCall[len(fake.queryInstalledChaincodesArgsForCall)]
 	fake.queryInstalledChaincodesArgsForCall = append(fake.queryInstalledChaincodesArgsForCall, struct {
-		options []resmgmt.RequestOption
-	}{options})
-	fake.recordInvocation("QueryInstalledChaincodes", []interface{}{options})
+		arg1 []resmgmt.RequestOption
+	}{arg1})
+	fake.recordInvocation("QueryInstalledChaincodes", []interface{}{arg1})
 	fake.queryInstalledChaincodesMutex.Unlock()
 	if fake.QueryInstalledChaincodesStub != nil {
-		return fake.QueryInstalledChaincodesStub(options...)
+		return fake.QueryInstalledChaincodesStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryInstalledChaincodesReturns.result1, fake.queryInstalledChaincodesReturns.result2
+	fakeReturns := fake.queryInstalledChaincodesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) QueryInstalledChaincodesCallCount() int {
@@ -622,50 +719,62 @@ func (fake *ResourceManagement) QueryInstalledChaincodesCallCount() int {
 	return len(fake.queryInstalledChaincodesArgsForCall)
 }
 
+func (fake *ResourceManagement) QueryInstalledChaincodesCalls(stub func(...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error)) {
+	fake.queryInstalledChaincodesMutex.Lock()
+	defer fake.queryInstalledChaincodesMutex.Unlock()
+	fake.QueryInstalledChaincodesStub = stub
+}
+
 func (fake *ResourceManagement) QueryInstalledChaincodesArgsForCall(i int) []resmgmt.RequestOption {
 	fake.queryInstalledChaincodesMutex.RLock()
 	defer fake.queryInstalledChaincodesMutex.RUnlock()
-	return fake.queryInstalledChaincodesArgsForCall[i].options
+	argsForCall := fake.queryInstalledChaincodesArgsForCall[i]
+	return argsForCall.arg1
 }
 
-func (fake *ResourceManagement) QueryInstalledChaincodesReturns(result1 *pb.ChaincodeQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryInstalledChaincodesReturns(result1 *peer.ChaincodeQueryResponse, result2 error) {
+	fake.queryInstalledChaincodesMutex.Lock()
+	defer fake.queryInstalledChaincodesMutex.Unlock()
 	fake.QueryInstalledChaincodesStub = nil
 	fake.queryInstalledChaincodesReturns = struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryInstalledChaincodesReturnsOnCall(i int, result1 *pb.ChaincodeQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryInstalledChaincodesReturnsOnCall(i int, result1 *peer.ChaincodeQueryResponse, result2 error) {
+	fake.queryInstalledChaincodesMutex.Lock()
+	defer fake.queryInstalledChaincodesMutex.Unlock()
 	fake.QueryInstalledChaincodesStub = nil
 	if fake.queryInstalledChaincodesReturnsOnCall == nil {
 		fake.queryInstalledChaincodesReturnsOnCall = make(map[int]struct {
-			result1 *pb.ChaincodeQueryResponse
+			result1 *peer.ChaincodeQueryResponse
 			result2 error
 		})
 	}
 	fake.queryInstalledChaincodesReturnsOnCall[i] = struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryInstantiatedChaincodes(channelID string, options ...resmgmt.RequestOption) (*pb.ChaincodeQueryResponse, error) {
+func (fake *ResourceManagement) QueryInstantiatedChaincodes(arg1 string, arg2 ...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error) {
 	fake.queryInstantiatedChaincodesMutex.Lock()
 	ret, specificReturn := fake.queryInstantiatedChaincodesReturnsOnCall[len(fake.queryInstantiatedChaincodesArgsForCall)]
 	fake.queryInstantiatedChaincodesArgsForCall = append(fake.queryInstantiatedChaincodesArgsForCall, struct {
-		channelID string
-		options   []resmgmt.RequestOption
-	}{channelID, options})
-	fake.recordInvocation("QueryInstantiatedChaincodes", []interface{}{channelID, options})
+		arg1 string
+		arg2 []resmgmt.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("QueryInstantiatedChaincodes", []interface{}{arg1, arg2})
 	fake.queryInstantiatedChaincodesMutex.Unlock()
 	if fake.QueryInstantiatedChaincodesStub != nil {
-		return fake.QueryInstantiatedChaincodesStub(channelID, options...)
+		return fake.QueryInstantiatedChaincodesStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.queryInstantiatedChaincodesReturns.result1, fake.queryInstantiatedChaincodesReturns.result2
+	fakeReturns := fake.queryInstantiatedChaincodesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) QueryInstantiatedChaincodesCallCount() int {
@@ -674,50 +783,62 @@ func (fake *ResourceManagement) QueryInstantiatedChaincodesCallCount() int {
 	return len(fake.queryInstantiatedChaincodesArgsForCall)
 }
 
+func (fake *ResourceManagement) QueryInstantiatedChaincodesCalls(stub func(string, ...resmgmt.RequestOption) (*peer.ChaincodeQueryResponse, error)) {
+	fake.queryInstantiatedChaincodesMutex.Lock()
+	defer fake.queryInstantiatedChaincodesMutex.Unlock()
+	fake.QueryInstantiatedChaincodesStub = stub
+}
+
 func (fake *ResourceManagement) QueryInstantiatedChaincodesArgsForCall(i int) (string, []resmgmt.RequestOption) {
 	fake.queryInstantiatedChaincodesMutex.RLock()
 	defer fake.queryInstantiatedChaincodesMutex.RUnlock()
-	return fake.queryInstantiatedChaincodesArgsForCall[i].channelID, fake.queryInstantiatedChaincodesArgsForCall[i].options
+	argsForCall := fake.queryInstantiatedChaincodesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *ResourceManagement) QueryInstantiatedChaincodesReturns(result1 *pb.ChaincodeQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryInstantiatedChaincodesReturns(result1 *peer.ChaincodeQueryResponse, result2 error) {
+	fake.queryInstantiatedChaincodesMutex.Lock()
+	defer fake.queryInstantiatedChaincodesMutex.Unlock()
 	fake.QueryInstantiatedChaincodesStub = nil
 	fake.queryInstantiatedChaincodesReturns = struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) QueryInstantiatedChaincodesReturnsOnCall(i int, result1 *pb.ChaincodeQueryResponse, result2 error) {
+func (fake *ResourceManagement) QueryInstantiatedChaincodesReturnsOnCall(i int, result1 *peer.ChaincodeQueryResponse, result2 error) {
+	fake.queryInstantiatedChaincodesMutex.Lock()
+	defer fake.queryInstantiatedChaincodesMutex.Unlock()
 	fake.QueryInstantiatedChaincodesStub = nil
 	if fake.queryInstantiatedChaincodesReturnsOnCall == nil {
 		fake.queryInstantiatedChaincodesReturnsOnCall = make(map[int]struct {
-			result1 *pb.ChaincodeQueryResponse
+			result1 *peer.ChaincodeQueryResponse
 			result2 error
 		})
 	}
 	fake.queryInstantiatedChaincodesReturnsOnCall[i] = struct {
-		result1 *pb.ChaincodeQueryResponse
+		result1 *peer.ChaincodeQueryResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) SaveChannel(req resmgmt.SaveChannelRequest, options ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error) {
+func (fake *ResourceManagement) SaveChannel(arg1 resmgmt.SaveChannelRequest, arg2 ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error) {
 	fake.saveChannelMutex.Lock()
 	ret, specificReturn := fake.saveChannelReturnsOnCall[len(fake.saveChannelArgsForCall)]
 	fake.saveChannelArgsForCall = append(fake.saveChannelArgsForCall, struct {
-		req     resmgmt.SaveChannelRequest
-		options []resmgmt.RequestOption
-	}{req, options})
-	fake.recordInvocation("SaveChannel", []interface{}{req, options})
+		arg1 resmgmt.SaveChannelRequest
+		arg2 []resmgmt.RequestOption
+	}{arg1, arg2})
+	fake.recordInvocation("SaveChannel", []interface{}{arg1, arg2})
 	fake.saveChannelMutex.Unlock()
 	if fake.SaveChannelStub != nil {
-		return fake.SaveChannelStub(req, options...)
+		return fake.SaveChannelStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.saveChannelReturns.result1, fake.saveChannelReturns.result2
+	fakeReturns := fake.saveChannelReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) SaveChannelCallCount() int {
@@ -726,13 +847,22 @@ func (fake *ResourceManagement) SaveChannelCallCount() int {
 	return len(fake.saveChannelArgsForCall)
 }
 
+func (fake *ResourceManagement) SaveChannelCalls(stub func(resmgmt.SaveChannelRequest, ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error)) {
+	fake.saveChannelMutex.Lock()
+	defer fake.saveChannelMutex.Unlock()
+	fake.SaveChannelStub = stub
+}
+
 func (fake *ResourceManagement) SaveChannelArgsForCall(i int) (resmgmt.SaveChannelRequest, []resmgmt.RequestOption) {
 	fake.saveChannelMutex.RLock()
 	defer fake.saveChannelMutex.RUnlock()
-	return fake.saveChannelArgsForCall[i].req, fake.saveChannelArgsForCall[i].options
+	argsForCall := fake.saveChannelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ResourceManagement) SaveChannelReturns(result1 resmgmt.SaveChannelResponse, result2 error) {
+	fake.saveChannelMutex.Lock()
+	defer fake.saveChannelMutex.Unlock()
 	fake.SaveChannelStub = nil
 	fake.saveChannelReturns = struct {
 		result1 resmgmt.SaveChannelResponse
@@ -741,6 +871,8 @@ func (fake *ResourceManagement) SaveChannelReturns(result1 resmgmt.SaveChannelRe
 }
 
 func (fake *ResourceManagement) SaveChannelReturnsOnCall(i int, result1 resmgmt.SaveChannelResponse, result2 error) {
+	fake.saveChannelMutex.Lock()
+	defer fake.saveChannelMutex.Unlock()
 	fake.SaveChannelStub = nil
 	if fake.saveChannelReturnsOnCall == nil {
 		fake.saveChannelReturnsOnCall = make(map[int]struct {
@@ -754,23 +886,24 @@ func (fake *ResourceManagement) SaveChannelReturnsOnCall(i int, result1 resmgmt.
 	}{result1, result2}
 }
 
-func (fake *ResourceManagement) UpgradeCC(channelID string, req resmgmt.UpgradeCCRequest, options ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error) {
+func (fake *ResourceManagement) UpgradeCC(arg1 string, arg2 resmgmt.UpgradeCCRequest, arg3 ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error) {
 	fake.upgradeCCMutex.Lock()
 	ret, specificReturn := fake.upgradeCCReturnsOnCall[len(fake.upgradeCCArgsForCall)]
 	fake.upgradeCCArgsForCall = append(fake.upgradeCCArgsForCall, struct {
-		channelID string
-		req       resmgmt.UpgradeCCRequest
-		options   []resmgmt.RequestOption
-	}{channelID, req, options})
-	fake.recordInvocation("UpgradeCC", []interface{}{channelID, req, options})
+		arg1 string
+		arg2 resmgmt.UpgradeCCRequest
+		arg3 []resmgmt.RequestOption
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpgradeCC", []interface{}{arg1, arg2, arg3})
 	fake.upgradeCCMutex.Unlock()
 	if fake.UpgradeCCStub != nil {
-		return fake.UpgradeCCStub(channelID, req, options...)
+		return fake.UpgradeCCStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.upgradeCCReturns.result1, fake.upgradeCCReturns.result2
+	fakeReturns := fake.upgradeCCReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ResourceManagement) UpgradeCCCallCount() int {
@@ -779,13 +912,22 @@ func (fake *ResourceManagement) UpgradeCCCallCount() int {
 	return len(fake.upgradeCCArgsForCall)
 }
 
+func (fake *ResourceManagement) UpgradeCCCalls(stub func(string, resmgmt.UpgradeCCRequest, ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error)) {
+	fake.upgradeCCMutex.Lock()
+	defer fake.upgradeCCMutex.Unlock()
+	fake.UpgradeCCStub = stub
+}
+
 func (fake *ResourceManagement) UpgradeCCArgsForCall(i int) (string, resmgmt.UpgradeCCRequest, []resmgmt.RequestOption) {
 	fake.upgradeCCMutex.RLock()
 	defer fake.upgradeCCMutex.RUnlock()
-	return fake.upgradeCCArgsForCall[i].channelID, fake.upgradeCCArgsForCall[i].req, fake.upgradeCCArgsForCall[i].options
+	argsForCall := fake.upgradeCCArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ResourceManagement) UpgradeCCReturns(result1 resmgmt.UpgradeCCResponse, result2 error) {
+	fake.upgradeCCMutex.Lock()
+	defer fake.upgradeCCMutex.Unlock()
 	fake.UpgradeCCStub = nil
 	fake.upgradeCCReturns = struct {
 		result1 resmgmt.UpgradeCCResponse
@@ -794,6 +936,8 @@ func (fake *ResourceManagement) UpgradeCCReturns(result1 resmgmt.UpgradeCCRespon
 }
 
 func (fake *ResourceManagement) UpgradeCCReturnsOnCall(i int, result1 resmgmt.UpgradeCCResponse, result2 error) {
+	fake.upgradeCCMutex.Lock()
+	defer fake.upgradeCCMutex.Unlock()
 	fake.UpgradeCCStub = nil
 	if fake.upgradeCCReturnsOnCall == nil {
 		fake.upgradeCCReturnsOnCall = make(map[int]struct {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -9,7 +9,5 @@ SPDX-License-Identifier: Apache-2.0
 package tools
 
 import (
-	_ "github.com/golangci/golangci-lint"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
-	_ "github.com/myitcv/gobin"
 )


### PR DESCRIPTION
- Updates to fabric-sdk-go:beta-1
- Regenerates mocks
- Fixes missing mock generator
- Removes ununsed "tool" imports to fix go mod tidy

Signed-off-by: Troy Ronda <troy@troyronda.com>