### PR TITLE
FAB-16997 Remove code causing err msg to be printed out twice

### DIFF
--- a/cmd/fabric.go
+++ b/cmd/fabric.go
@@ -65,7 +65,6 @@ func main() {
 	cmd := NewDefaultFabricCommand(settings, os.Args[1:])
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(settings.Streams.Err, "%v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Remove the unuseful code of fabric.go line 68.It will let the error
output twice.Cobra will help bin output the error.Just like peer ,we 
should remove it.

Signed-off-by: TopJohn <xzj19922010@gmail.com>