### PR TITLE
[FAB-17920] Added retries to Invoke and Query

### DIFF
--- a/cmd/commands/chaincode/invoke.go
+++ b/cmd/commands/chaincode/invoke.go
@@ -11,10 +11,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-cli/pkg/environment"
-	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 )
 
 // NewChaincodeInvokeCommand creates a new "fabric chaincode invoke" command
@@ -86,7 +87,7 @@ func (c *InvokeCommand) Run() error {
 		Args:        [][]byte{args},
 	}
 
-	resp, err := c.Channel.Execute(req)
+	resp, err := c.Channel.Execute(req, channel.WithRetry(retry.DefaultChannelOpts))
 	if err != nil {
 		return err
 	}

--- a/cmd/commands/chaincode/query.go
+++ b/cmd/commands/chaincode/query.go
@@ -11,10 +11,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-cli/pkg/environment"
-	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 )
 
 // NewChaincodeQueryCommand creates a new "fabric chaincode query" command
@@ -86,7 +87,7 @@ func (c *QueryCommand) Run() error {
 		Args:        [][]byte{args},
 	}
 
-	resp, err := c.Channel.Query(req)
+	resp, err := c.Channel.Query(req, channel.WithRetry(retry.DefaultChannelOpts))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added retry options to channel Invoke and Query so that retries are performed on transient errors, such as connection failed.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>