### PR TITLE
[FAB-18136] Lifecycle package command

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -7,14 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package commands
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hyperledger/fabric-cli/cmd/commands/chaincode"
 	"github.com/hyperledger/fabric-cli/cmd/commands/channel"
 	"github.com/hyperledger/fabric-cli/cmd/commands/context"
+	"github.com/hyperledger/fabric-cli/cmd/commands/lifecycle"
 	"github.com/hyperledger/fabric-cli/cmd/commands/network"
 	"github.com/hyperledger/fabric-cli/cmd/commands/plugin"
 	"github.com/hyperledger/fabric-cli/cmd/commands/version"
 	"github.com/hyperledger/fabric-cli/pkg/environment"
-	"github.com/spf13/cobra"
 )
 
 // All returns all subcommands that will be added to the root command
@@ -38,5 +40,8 @@ func All(settings *environment.Settings) []*cobra.Command {
 
 		// fabric version
 		version.NewVersionCommand(settings),
+
+		// fabric lifecycle [subcommand]
+		lifecycle.NewCommand(settings),
 	}
 }

--- a/cmd/commands/lifecycle/lifecycle.go
+++ b/cmd/commands/lifecycle/lifecycle.go
@@ -1,0 +1,64 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/cmd/common"
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric"
+)
+
+// NewCommand creates a new "fabric lifecycle" command
+func NewCommand(settings *environment.Settings) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lifecycle",
+		Short: "Manage chaincode lifecycle",
+	}
+
+	cmd.AddCommand(
+		NewPackageCommand(settings),
+	)
+
+	cmd.SetOutput(settings.Streams.Out)
+
+	return cmd
+}
+
+// BaseCommand implements common channel command functions
+type BaseCommand struct {
+	common.Command
+
+	Factory            fabric.Factory
+	Channel            fabric.Channel
+	ResourceManagement fabric.ResourceManagement
+}
+
+// Complete initializes all clients needed for Run
+func (c *BaseCommand) Complete() error {
+	var err error
+
+	if c.Factory == nil {
+		c.Factory, err = fabric.NewFactory(c.Settings.Config)
+		if err != nil {
+			return err
+		}
+	}
+
+	c.Channel, err = c.Factory.Channel()
+	if err != nil {
+		return err
+	}
+
+	c.ResourceManagement, err = c.Factory.ResourceManagement()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/commands/lifecycle/lifecycle_test.go
+++ b/cmd/commands/lifecycle/lifecycle_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/cmd/commands/lifecycle"
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric/mocks"
+)
+
+func TestLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lifecycle Suite")
+}
+
+var _ = Describe("LifecycleChaincodeCommand", func() {
+	var (
+		cmd      *cobra.Command
+		settings *environment.Settings
+		out      *bytes.Buffer
+	)
+
+	Context("when creating a command from settings", func() {
+		BeforeEach(func() {
+			out = new(bytes.Buffer)
+
+			settings = &environment.Settings{
+				Home: environment.Home(os.TempDir()),
+				Streams: environment.Streams{
+					Out: out,
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			cmd = lifecycle.NewCommand(settings)
+		})
+
+		It("should create a lifecycle command", func() {
+			Expect(cmd.Name()).To(Equal("lifecycle"))
+			Expect(cmd.HasSubCommands()).To(BeTrue())
+			Expect(cmd.Execute()).Should(Succeed())
+			Expect(fmt.Sprint(out)).To(ContainSubstring("lifecycle [command]"))
+			Expect(fmt.Sprint(out)).To(ContainSubstring("package"))
+		})
+	})
+})
+
+var _ = Describe("LifecycleBaseChaincodeCommand", func() {
+	var c *lifecycle.BaseCommand
+
+	BeforeEach(func() {
+		c = &lifecycle.BaseCommand{}
+	})
+
+	Describe("Complete", func() {
+		var (
+			err           error
+			factory       *mocks.Factory
+			channelClient *mocks.Channel
+			resmgmtClient *mocks.ResourceManagement
+		)
+
+		BeforeEach(func() {
+			factory = &mocks.Factory{}
+			channelClient = &mocks.Channel{}
+			resmgmtClient = &mocks.ResourceManagement{}
+
+			factory.ResourceManagementReturns(resmgmtClient, nil)
+			factory.ChannelReturns(channelClient, nil)
+
+			c.Factory = factory
+		})
+
+		JustBeforeEach(func() {
+			err = c.Complete()
+		})
+
+		It("should complete", func() {
+			Expect(err).To(BeNil())
+			Expect(c.Channel).NotTo(BeNil())
+		})
+
+		Context("when factory fails to create channel client", func() {
+			BeforeEach(func() {
+				factory.ChannelReturns(nil, errors.New("factory error"))
+			})
+
+			It("should fail with factory error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("when factory fails to create resmgmt client", func() {
+			BeforeEach(func() {
+				factory.ResourceManagementReturns(nil, errors.New("factory error"))
+			})
+
+			It("should fail with factory error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+	})
+})

--- a/cmd/commands/lifecycle/package.go
+++ b/cmd/commands/lifecycle/package.go
@@ -1,0 +1,98 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	lifecyclepkg "github.com/hyperledger/fabric-sdk-go/pkg/fab/ccpackager/lifecycle"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+)
+
+// NewPackageCommand creates a new "fabric lifecycle chaincode package" command
+func NewPackageCommand(settings *environment.Settings) *cobra.Command {
+	c := PackageCommand{}
+
+	c.Settings = settings
+
+	cmd := &cobra.Command{
+		Use:   "package <chaincode-label> <chaincode-type> <path>",
+		Short: "package a chaincode",
+		Args:  c.ParseArgs(),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return c.Validate()
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.Run()
+		},
+	}
+
+	c.AddArg(&c.Label)
+	c.AddArg(&c.Type)
+	c.AddArg(&c.Path)
+
+	cmd.SetOutput(c.Settings.Streams.Out)
+
+	return cmd
+}
+
+// PackageCommand implements the chaincode package command
+type PackageCommand struct {
+	BaseCommand
+
+	Path  string
+	Label string
+	Type  string
+}
+
+// Validate checks the required parameters for run
+func (c *PackageCommand) Validate() error {
+	if c.Label == "" {
+		return errors.New("chaincode label not specified")
+	}
+
+	if c.Path == "" {
+		return errors.New("chaincode path not specified")
+	}
+
+	if c.Type == "" {
+		return errors.New("chaincode type not specified")
+	}
+
+	ccType, ok := pb.ChaincodeSpec_Type_value[strings.ToUpper(c.Type)]
+	if !ok || ccType == int32(pb.ChaincodeSpec_UNDEFINED) {
+		return errors.New("unsupported chaincode type")
+	}
+
+	return nil
+}
+
+// Run executes the command
+func (c *PackageCommand) Run() error {
+	pkgBytes, err := lifecyclepkg.NewCCPackage(&lifecyclepkg.Descriptor{
+		Path:  c.Path,
+		Type:  pb.ChaincodeSpec_Type(pb.ChaincodeSpec_Type_value[strings.ToUpper(c.Type)]),
+		Label: c.Label,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(fmt.Sprintf("./%s.tgz", c.Label), pkgBytes, 0644); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(c.Settings.Streams.Out, "successfully packaged chaincode '%s'\n", c.Label)
+
+	return nil
+}

--- a/cmd/commands/lifecycle/package_test.go
+++ b/cmd/commands/lifecycle/package_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/cmd/commands/lifecycle"
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+)
+
+var _ = Describe("LifecycleChaincodePackageCommand", func() {
+	var (
+		cmd      *cobra.Command
+		settings *environment.Settings
+		out      *bytes.Buffer
+
+		args []string
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		args = os.Args
+	})
+
+	JustBeforeEach(func() {
+		cmd = lifecycle.NewPackageCommand(settings)
+	})
+
+	AfterEach(func() {
+		os.Args = args
+	})
+
+	It("should create a chaincode package command", func() {
+		Expect(cmd.Name()).To(Equal("package"))
+		Expect(cmd.HasSubCommands()).To(BeFalse())
+	})
+
+	It("should provide a help prompt", func() {
+		os.Args = append(os.Args, "--help")
+
+		Expect(cmd.Execute()).Should(Succeed())
+		Expect(fmt.Sprint(out)).To(ContainSubstring("package <chaincode-label> <chaincode-type> <path>"))
+	})
+})
+
+var _ = Describe("LifecycleChaincodePackageImplementation", func() {
+	var (
+		impl     *lifecycle.PackageCommand
+		err      error
+		out      *bytes.Buffer
+		settings *environment.Settings
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		impl = &lifecycle.PackageCommand{}
+		impl.Settings = settings
+	})
+
+	It("should not be nil", func() {
+		Expect(impl).ShouldNot(BeNil())
+	})
+
+	Describe("Validate", func() {
+		JustBeforeEach(func() {
+			err = impl.Validate()
+		})
+
+		It("should fail when label is not set", func() {
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal("chaincode label not specified"))
+		})
+
+		Context("when chaincode path is not set", func() {
+			BeforeEach(func() {
+				impl.Label = "mycc"
+			})
+
+			It("should fail without chaincode path", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("chaincode path not specified"))
+			})
+		})
+
+		Context("when all arguments are set", func() {
+			BeforeEach(func() {
+				impl.Label = "mycc"
+				impl.Path = "path"
+				impl.Type = "golang"
+			})
+
+			It("should succeed with all arguments", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Run", func() {
+		BeforeEach(func() {
+			impl.Label = "mycc"
+			impl.Path = "github.com/hyperledger/fabric-cli/cmd/commands/lifecycle/testdata/chaincode/example/example.go"
+		})
+
+		JustBeforeEach(func() {
+			err = impl.Run()
+		})
+
+		Context("when chaincode path is invalid", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {},
+					},
+					CurrentContext: "foo",
+				}
+
+				impl.Path = "path/to/chaincode"
+			})
+
+			It("should fail with an invalid path", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+	})
+})

--- a/cmd/commands/lifecycle/testdata/chaincode/example/example.go
+++ b/cmd/commands/lifecycle/testdata/chaincode/example/example.go
@@ -1,0 +1,34 @@
+/*
+Copyright State Street Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+// Chaincode is a simple chaincode implementation
+type Chaincode struct{}
+
+// Init - Initializes the chaincode
+func (cc *Chaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+// Invoke - invokes the chaincode
+func (cc *Chaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+func main() {
+	err := shim.Start(new(Chaincode))
+	if err != nil {
+		fmt.Printf("Error starting chaincode: %s", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.12
 
 require (
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23
-	github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200724161828-7b97fdf0b97a
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200807145244-92e563b57775
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.1
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDW
 github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23 h1:SEbB3yH4ISTGRifDamYXAst36gO2kM855ndMJlsv+pc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200724161828-7b97fdf0b97a h1:+OO4PG3FLKf7chQKJC+kh52n+G1UK1c7y5uDTIeqwZo=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200724161828-7b97fdf0b97a/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200807145244-92e563b57775 h1:nMJFKukVBrfDW3tWXo9OuTXMxP6bc4m5spGgw1Ou1b0=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta2.0.20200807145244-92e563b57775/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Added a 'lifecycle' command and a 'package' sub-command that packages a chaincode using Fabric 2.0 chaincode lifecycle.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>