### PR TITLE
[FAB-18140] Lifecycle approve command

### DIFF
--- a/cmd/commands/chaincode/instantiate.go
+++ b/cmd/commands/chaincode/instantiate.go
@@ -11,9 +11,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hyperledger/fabric-cli/cmd/commands/common"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
-
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-cli/pkg/environment"
@@ -101,12 +101,12 @@ func (c *InstantiateCommand) Run() error {
 		return err
 	}
 
-	policy, err := getChaincodePolicy(c.ChaincodePolicy)
+	policy, err := common.GetChaincodePolicy(c.ChaincodePolicy)
 	if err != nil {
 		return err
 	}
 
-	collectionsConfig, err := getCollectionConfigFromFile(c.ChaincodeCollectionsConfig)
+	collectionsConfig, err := common.GetCollectionConfigFromFile(c.ChaincodeCollectionsConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/commands/chaincode/upgrade.go
+++ b/cmd/commands/chaincode/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/spf13/cobra"
 
+	"github.com/hyperledger/fabric-cli/cmd/commands/common"
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 )
 
@@ -100,12 +101,12 @@ func (c *UpgradeCommand) Run() error {
 		return err
 	}
 
-	policy, err := getChaincodePolicy(c.ChaincodePolicy)
+	policy, err := common.GetChaincodePolicy(c.ChaincodePolicy)
 	if err != nil {
 		return err
 	}
 
-	collectionsConfig, err := getCollectionConfigFromFile(c.ChaincodeCollectionsConfig)
+	collectionsConfig, err := common.GetCollectionConfigFromFile(c.ChaincodeCollectionsConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/commands/common/common.go
+++ b/cmd/commands/common/common.go
@@ -1,4 +1,4 @@
-package chaincode
+package common
 
 import (
 	"encoding/json"
@@ -11,7 +11,8 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/common/policydsl"
 )
 
-type collectionConfigJSON struct {
+// CollectionConfigJSON contains the parameters for a collection configuration
+type CollectionConfigJSON struct {
 	Name            string `json:"name"`
 	Policy          string `json:"policy"`
 	RequiredCount   int32  `json:"requiredPeerCount"`
@@ -21,7 +22,8 @@ type collectionConfigJSON struct {
 	MemberOnlyWrite bool   `json:"memberOnlyWrite"`
 }
 
-func getCollectionConfigFromFile(path string) ([]*pb.CollectionConfig, error) {
+// GetCollectionConfigFromFile returns the collection config from the given file
+func GetCollectionConfigFromFile(path string) ([]*pb.CollectionConfig, error) {
 	if len(path) == 0 {
 		return nil, nil
 	}
@@ -31,11 +33,12 @@ func getCollectionConfigFromFile(path string) ([]*pb.CollectionConfig, error) {
 		return nil, errors.New("error reading collections config file")
 	}
 
-	return getCollectionsConfigFromBytes(bytes)
+	return GetCollectionsConfigFromBytes(bytes)
 }
 
-func getCollectionsConfigFromBytes(bytes []byte) ([]*pb.CollectionConfig, error) {
-	var cconf []collectionConfigJSON
+// GetCollectionsConfigFromBytes returns the collection config from the given byte array
+func GetCollectionsConfigFromBytes(bytes []byte) ([]*pb.CollectionConfig, error) {
+	var cconf []CollectionConfigJSON
 	if err := json.Unmarshal(bytes, &cconf); err != nil {
 		return nil, errors.New("error unmarshalling collections config")
 	}
@@ -66,7 +69,8 @@ func getCollectionsConfigFromBytes(bytes []byte) ([]*pb.CollectionConfig, error)
 	return ccarray, nil
 }
 
-func getChaincodePolicy(policyString string) (*common.SignaturePolicyEnvelope, error) {
+// GetChaincodePolicy returns the signature policy from the given policy string
+func GetChaincodePolicy(policyString string) (*common.SignaturePolicyEnvelope, error) {
 	if len(policyString) == 0 {
 		return policydsl.AcceptAllPolicy, nil
 	}

--- a/cmd/commands/common/common_test.go
+++ b/cmd/commands/common/common_test.go
@@ -1,4 +1,4 @@
-package chaincode
+package common
 
 import (
 	"testing"
@@ -28,25 +28,25 @@ const sampleCollectionsConfigBad = `[
 ]`
 
 func TestGetCollectionsConfigFromBytes(t *testing.T) {
-	config, err := getCollectionsConfigFromBytes([]byte(sampleCollectionsConfigGood))
+	config, err := GetCollectionsConfigFromBytes([]byte(sampleCollectionsConfigGood))
 	assert.Nil(t, err)
 	assert.NotNil(t, config)
 }
 
 func TestGetCollectionsConfigFromBytesError(t *testing.T) {
-	config, err := getCollectionsConfigFromBytes([]byte(sampleCollectionsConfigBad))
+	config, err := GetCollectionsConfigFromBytes([]byte(sampleCollectionsConfigBad))
 	assert.NotNil(t, err)
 	assert.Nil(t, config)
 }
 
 func TestGetChaincodePolicy(t *testing.T) {
-	policy, err := getChaincodePolicy("OR('MSP.member', 'MSP.WITH.DOTS.member', 'MSP-WITH-DASHES.member')")
+	policy, err := GetChaincodePolicy("OR('MSP.member', 'MSP.WITH.DOTS.member', 'MSP-WITH-DASHES.member')")
 	assert.Nil(t, err)
 	assert.NotNil(t, policy)
 }
 
 func TestGetChaincodePolicyError(t *testing.T) {
-	policy, err := getChaincodePolicy("NOT A VALID POLICY)")
+	policy, err := GetChaincodePolicy("NOT A VALID POLICY)")
 	assert.NotNil(t, err)
 	assert.Nil(t, policy)
 }

--- a/cmd/commands/lifecycle/approve.go
+++ b/cmd/commands/lifecycle/approve.go
@@ -1,0 +1,159 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/cmd/commands/common"
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+)
+
+// NewCommitCommand creates a new "fabric chaincode approve" command
+func NewApproveCommand(settings *environment.Settings) *cobra.Command {
+	c := ApproveCommand{}
+
+	c.Settings = settings
+
+	cmd := &cobra.Command{
+		Use:   "approve <chaincode-name> <version> <package-id> <sequence>",
+		Short: "approve a chaincode for an org",
+		Args:  c.ParseArgs(),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if err := c.Complete(); err != nil {
+				return err
+			}
+
+			if err := c.Validate(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.Run()
+		},
+	}
+
+	c.AddArg(&c.Name)
+	c.AddArg(&c.Version)
+	c.AddArg(&c.PackageID)
+	c.AddArg(&c.Sequence)
+
+	flags := cmd.Flags()
+	flags.StringVar(&c.SignaturePolicy, "policy", "", "sets the signature policy")
+	flags.StringVar(&c.ChannelConfigPolicy, "channel-config-policy", "", "sets the channel config policy")
+	flags.StringVar(&c.CollectionsConfig, "collections-config", "", "sets the path to the collections config file")
+	flags.BoolVar(&c.InitRequired, "init-required", false, "indicates whether the chaincode requires 'Init' to be invoked")
+	flags.StringVar(&c.EndorsementPlugin, "endorsement-plugin", "", "sets the endorsement plugin")
+	flags.StringVar(&c.ValidationPlugin, "validation-plugin", "", "sets the validation plugin")
+
+	cmd.SetOutput(c.Settings.Streams.Out)
+
+	return cmd
+}
+
+// ApproveCommand implements the chaincode instantiate command
+type ApproveCommand struct {
+	BaseCommand
+
+	Name                string
+	Version             string
+	PackageID           string
+	SignaturePolicy     string
+	ChannelConfigPolicy string
+	CollectionsConfig   string
+	Sequence            string
+	InitRequired        bool
+	EndorsementPlugin   string
+	ValidationPlugin    string
+}
+
+// Validate checks the required parameters for run
+func (c *ApproveCommand) Validate() error {
+	if c.Name == "" {
+		return errors.New("chaincode name not specified")
+	}
+
+	if c.Version == "" {
+		return errors.New("chaincode version not specified")
+	}
+
+	if c.PackageID == "" {
+		return errors.New("chaincode package ID not specified")
+	}
+
+	if c.Sequence == "" {
+		return errors.New("sequence not specified")
+	}
+
+	sequence, err := strconv.ParseInt(c.Sequence, 10, 64)
+	if err != nil {
+		return errors.WithMessage(err, "invalid sequence")
+	}
+
+	if sequence <= 0 {
+		return errors.New("sequence must be greater than 0")
+	}
+
+	return nil
+}
+
+// Run executes the command
+func (c *ApproveCommand) Run() error {
+	context, err := c.Settings.Config.GetCurrentContext()
+	if err != nil {
+		return err
+	}
+
+	signaturePolicy, err := common.GetChaincodePolicy(c.SignaturePolicy)
+	if err != nil {
+		return err
+	}
+
+	collectionsConfig, err := common.GetCollectionConfigFromFile(c.CollectionsConfig)
+	if err != nil {
+		return err
+	}
+
+	sequence, err := strconv.ParseInt(c.Sequence, 10, 64)
+	if err != nil {
+		return errors.WithMessage(err, "invalid sequence")
+	}
+
+	req := resmgmt.LifecycleApproveCCRequest{
+		Name:                c.Name,
+		Version:             c.Version,
+		PackageID:           c.PackageID,
+		Sequence:            sequence,
+		SignaturePolicy:     signaturePolicy,
+		ChannelConfigPolicy: c.ChannelConfigPolicy,
+		CollectionConfig:    collectionsConfig,
+		InitRequired:        c.InitRequired,
+		EndorsementPlugin:   c.EndorsementPlugin,
+		ValidationPlugin:    c.ValidationPlugin,
+	}
+
+	options := []resmgmt.RequestOption{
+		resmgmt.WithTargetEndpoints(context.Peers...),
+		resmgmt.WithRetry(retry.DefaultResMgmtOpts),
+	}
+
+	if _, err := c.ResourceManagement.LifecycleApproveCC(context.Channel, req, options...); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(c.Settings.Streams.Out, "successfully approved chaincode '%s'\n", c.Name)
+
+	return nil
+}

--- a/cmd/commands/lifecycle/approve_test.go
+++ b/cmd/commands/lifecycle/approve_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hyperledger/fabric-cli/cmd/commands/lifecycle"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric/mocks"
+)
+
+var _ = Describe("LifecycleApproveCommand", func() {
+	var (
+		cmd      *cobra.Command
+		settings *environment.Settings
+		out      *bytes.Buffer
+
+		args []string
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		args = os.Args
+	})
+
+	JustBeforeEach(func() {
+		cmd = lifecycle.NewApproveCommand(settings)
+	})
+
+	AfterEach(func() {
+		os.Args = args
+	})
+
+	It("should create a lifecycle approve command", func() {
+		Expect(cmd.Name()).To(Equal("approve"))
+		Expect(cmd.HasSubCommands()).To(BeFalse())
+	})
+
+	It("should provide a help prompt", func() {
+		os.Args = append(os.Args, "--help")
+
+		Expect(cmd.Execute()).Should(Succeed())
+		Expect(fmt.Sprint(out)).To(ContainSubstring("approve <chaincode-name> <version> <package-id> <sequence>"))
+	})
+})
+
+var _ = Describe("LifecycleApproveImplementation", func() {
+	var (
+		impl     *lifecycle.ApproveCommand
+		err      error
+		out      *bytes.Buffer
+		settings *environment.Settings
+		factory  *mocks.Factory
+		client   *mocks.ResourceManagement
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		factory = &mocks.Factory{}
+		client = &mocks.ResourceManagement{}
+
+		impl = &lifecycle.ApproveCommand{}
+		impl.Settings = settings
+		impl.Factory = factory
+	})
+
+	It("should not be nil", func() {
+		Expect(impl).ShouldNot(BeNil())
+	})
+
+	Describe("Validate", func() {
+		JustBeforeEach(func() {
+			err = impl.Validate()
+		})
+
+		It("should fail when name is not set", func() {
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal("chaincode name not specified"))
+		})
+
+		Context("when chaincode version is not set", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+			})
+
+			It("should fail without chaincode version", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("chaincode version not specified"))
+			})
+		})
+
+		Context("when chaincode package ID is not set", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+				impl.Version = "0.0.0"
+			})
+
+			It("should fail without chaincode package ID", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("chaincode package ID not specified"))
+			})
+		})
+
+		Context("when chaincode sequence is not set", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+				impl.Version = "0.0.0"
+				impl.PackageID = "pkg1"
+			})
+
+			It("should fail without chaincode sequence", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("sequence not specified"))
+			})
+		})
+
+		Context("when chaincode sequence is not greater than 0", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+				impl.Version = "0.0.0"
+				impl.PackageID = "pkg1"
+				impl.Sequence = "-1"
+			})
+
+			It("should fail with chaincode sequence not greater than 0", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("sequence must be greater than 0"))
+			})
+		})
+
+		Context("when chaincode sequence is invalid", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+				impl.Version = "0.0.0"
+				impl.PackageID = "pkg1"
+				impl.Sequence = "xxx"
+			})
+
+			It("should fail with chaincode sequence is invalid", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("invalid sequence"))
+			})
+		})
+
+		Context("when all arguments are set", func() {
+			BeforeEach(func() {
+				impl.Name = "mycc"
+				impl.Version = "0.0.0"
+				impl.PackageID = "pkg1"
+				impl.Sequence = "1"
+			})
+
+			It("should succeed with all arguments", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Run", func() {
+		BeforeEach(func() {
+			impl.Name = "mycc"
+			impl.Version = "0.0.0"
+			impl.Sequence = "1"
+			impl.ResourceManagement = client
+		})
+
+		JustBeforeEach(func() {
+			err = impl.Run()
+		})
+
+		It("should fail without a current context", func() {
+			Expect(err).NotTo(BeNil())
+		})
+
+		Context("when resmgmt client succeeds", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {},
+					},
+					CurrentContext: "foo",
+				}
+
+				client.InstantiateCCReturns(resmgmt.InstantiateCCResponse{}, nil)
+			})
+
+			It("should succeed with chaincode approve", func() {
+				Expect(err).To(BeNil())
+				Expect(fmt.Sprint(out)).To(Equal("successfully approved chaincode 'mycc'\n"))
+			})
+		})
+
+		Context("when resmgmt client fails", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {},
+					},
+					CurrentContext: "foo",
+				}
+
+				client.LifecycleApproveCCReturns(fab.TransactionID(""), errors.New("approve error"))
+			})
+
+			It("should fail to approve chaincode", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("approve error"))
+			})
+		})
+	})
+})

--- a/cmd/commands/lifecycle/lifecycle.go
+++ b/cmd/commands/lifecycle/lifecycle.go
@@ -24,6 +24,7 @@ func NewCommand(settings *environment.Settings) *cobra.Command {
 	cmd.AddCommand(
 		NewPackageCommand(settings),
 		NewInstallCommand(settings),
+		NewApproveCommand(settings),
 	)
 
 	cmd.SetOutput(settings.Streams.Out)

--- a/cmd/commands/lifecycle/lifecycle_test.go
+++ b/cmd/commands/lifecycle/lifecycle_test.go
@@ -57,6 +57,7 @@ var _ = Describe("LifecycleChaincodeCommand", func() {
 			Expect(fmt.Sprint(out)).To(ContainSubstring("lifecycle [command]"))
 			Expect(fmt.Sprint(out)).To(ContainSubstring("package"))
 			Expect(fmt.Sprint(out)).To(ContainSubstring("install"))
+			Expect(fmt.Sprint(out)).To(ContainSubstring("approve"))
 		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.1
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.9.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0 // indirect

--- a/pkg/fabric/interfaces.go
+++ b/pkg/fabric/interfaces.go
@@ -84,6 +84,7 @@ type ResourceManagement interface {
 	SaveChannel(req resmgmt.SaveChannelRequest, options ...resmgmt.RequestOption) (resmgmt.SaveChannelResponse, error)
 	UpgradeCC(channelID string, req resmgmt.UpgradeCCRequest, options ...resmgmt.RequestOption) (resmgmt.UpgradeCCResponse, error)
 	LifecycleInstallCC(req resmgmt.LifecycleInstallCCRequest, options ...resmgmt.RequestOption) ([]resmgmt.LifecycleInstallCCResponse, error)
+	LifecycleApproveCC(channelID string, req resmgmt.LifecycleApproveCCRequest, options ...resmgmt.RequestOption) (fab.TransactionID, error)
 }
 
 // MSP defines the methods implemented by SDK msp client

--- a/pkg/fabric/mocks/resmgmt.go
+++ b/pkg/fabric/mocks/resmgmt.go
@@ -195,6 +195,21 @@ type ResourceManagement struct {
 		result1 []resmgmt.LifecycleInstallCCResponse
 		result2 error
 	}
+	LifecycleApproveCCStub        func(channelID string, req resmgmt.LifecycleApproveCCRequest, options ...resmgmt.RequestOption) (fab.TransactionID, error)
+	lifecycleApproveCCMutex       sync.RWMutex
+	lifecycleApproveCCArgsForCall []struct {
+		channelID string
+		req       resmgmt.LifecycleApproveCCRequest
+		options   []resmgmt.RequestOption
+	}
+	lifecycleApproveCCReturns struct {
+		result1 fab.TransactionID
+		result2 error
+	}
+	lifecycleApproveCCReturnsOnCall map[int]struct {
+		result1 fab.TransactionID
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -873,6 +888,59 @@ func (fake *ResourceManagement) LifecycleInstallCCReturnsOnCall(i int, result1 [
 	}{result1, result2}
 }
 
+func (fake *ResourceManagement) LifecycleApproveCC(channelID string, req resmgmt.LifecycleApproveCCRequest, options ...resmgmt.RequestOption) (fab.TransactionID, error) {
+	fake.lifecycleApproveCCMutex.Lock()
+	ret, specificReturn := fake.lifecycleApproveCCReturnsOnCall[len(fake.lifecycleApproveCCArgsForCall)]
+	fake.lifecycleApproveCCArgsForCall = append(fake.lifecycleApproveCCArgsForCall, struct {
+		channelID string
+		req       resmgmt.LifecycleApproveCCRequest
+		options   []resmgmt.RequestOption
+	}{channelID, req, options})
+	fake.recordInvocation("LifecycleApproveCC", []interface{}{channelID, req, options})
+	fake.lifecycleApproveCCMutex.Unlock()
+	if fake.LifecycleApproveCCStub != nil {
+		return fake.LifecycleApproveCCStub(channelID, req, options...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.lifecycleApproveCCReturns.result1, fake.lifecycleApproveCCReturns.result2
+}
+
+func (fake *ResourceManagement) LifecycleApproveCCCallCount() int {
+	fake.lifecycleApproveCCMutex.RLock()
+	defer fake.lifecycleApproveCCMutex.RUnlock()
+	return len(fake.lifecycleApproveCCArgsForCall)
+}
+
+func (fake *ResourceManagement) LifecycleApproveCCArgsForCall(i int) (string, resmgmt.LifecycleApproveCCRequest, []resmgmt.RequestOption) {
+	fake.lifecycleApproveCCMutex.RLock()
+	defer fake.lifecycleApproveCCMutex.RUnlock()
+	return fake.lifecycleApproveCCArgsForCall[i].channelID, fake.lifecycleApproveCCArgsForCall[i].req, fake.lifecycleApproveCCArgsForCall[i].options
+}
+
+func (fake *ResourceManagement) LifecycleApproveCCReturns(result1 fab.TransactionID, result2 error) {
+	fake.LifecycleApproveCCStub = nil
+	fake.lifecycleApproveCCReturns = struct {
+		result1 fab.TransactionID
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ResourceManagement) LifecycleApproveCCReturnsOnCall(i int, result1 fab.TransactionID, result2 error) {
+	fake.LifecycleApproveCCStub = nil
+	if fake.lifecycleApproveCCReturnsOnCall == nil {
+		fake.lifecycleApproveCCReturnsOnCall = make(map[int]struct {
+			result1 fab.TransactionID
+			result2 error
+		})
+	}
+	fake.lifecycleApproveCCReturnsOnCall[i] = struct {
+		result1 fab.TransactionID
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ResourceManagement) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -902,6 +970,8 @@ func (fake *ResourceManagement) Invocations() map[string][][]interface{} {
 	defer fake.upgradeCCMutex.RUnlock()
 	fake.lifecycleInstallCCMutex.RLock()
 	defer fake.lifecycleInstallCCMutex.RUnlock()
+	fake.lifecycleApproveCCMutex.RLock()
+	defer fake.lifecycleApproveCCMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Implemented the lifecycle approve command which allows an org to approve a chaincode package.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>