### PR TITLE
[FAB-18151] Fix panic in lifecycle install

### DIFF
--- a/cmd/commands/lifecycle/install.go
+++ b/cmd/commands/lifecycle/install.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/ccpackager/lifecycle"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-cli/pkg/environment"
@@ -97,7 +98,12 @@ func (c *InstallCommand) Run() error {
 		return err
 	}
 
-	fmt.Fprintf(c.Settings.Streams.Out, "successfully installed chaincode '%s'. Package ID '%s'\n", c.Label, responses[0].PackageID)
+	if len(responses) == 0 {
+		packageID := lifecycle.ComputePackageID(c.Label, pkg)
+		fmt.Fprintf(c.Settings.Streams.Out, "chaincode '%s' has already been installed on all peers. Package ID '%s'\n", c.Label, packageID)
+	} else {
+		fmt.Fprintf(c.Settings.Streams.Out, "successfully installed chaincode '%s'. Package ID '%s'\n", c.Label, responses[0].PackageID)
+	}
 
 	return nil
 }

--- a/cmd/commands/lifecycle/install_test.go
+++ b/cmd/commands/lifecycle/install_test.go
@@ -179,12 +179,36 @@ var _ = Describe("LifecycleChaincodeInstallImplementation", func() {
 					CurrentContext: "foo",
 				}
 
-				client.InstallCCReturns([]resmgmt.InstallCCResponse{}, nil)
+				client.LifecycleInstallCCReturns([]resmgmt.LifecycleInstallCCResponse{
+					{
+						Target:    "peer1",
+						Status:    200,
+						PackageID: "pkg1",
+					},
+				}, nil)
 			})
 
 			It("should succeed with chaincode install", func() {
 				Expect(err).To(BeNil())
 				Expect(fmt.Sprint(out)).To(Equal("successfully installed chaincode 'mycc'. Package ID 'pkg1'\n"))
+			})
+		})
+
+		Context("when no responses from client", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {},
+					},
+					CurrentContext: "foo",
+				}
+
+				client.LifecycleInstallCCReturns(nil, nil)
+			})
+
+			It("should succeed with chaincode install", func() {
+				Expect(err).To(BeNil())
+				Expect(fmt.Sprint(out)).To(ContainSubstring("chaincode 'mycc' has already been installed on all peers"))
 			})
 		})
 


### PR DESCRIPTION
If a chaincode has already been installed then the response from LifecycleInstallCC is empty. In this case, output a different message.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>