### PR TITLE
[FAB-18141] Implemented lifecycle queryapproved command

### DIFF
--- a/cmd/commands/lifecycle/lifecycle.go
+++ b/cmd/commands/lifecycle/lifecycle.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package lifecycle
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -16,7 +17,12 @@ import (
 	"github.com/hyperledger/fabric-cli/pkg/fabric"
 )
 
-const jsonFormat = "json"
+const (
+	jsonFormat = "json"
+
+	outputFormatUsage = `The output format for query results. If set to 'json' then the response is output in JSON format,
+otherwise the response is output in human-readable text.`
+)
 
 // NewCommand creates a new "fabric lifecycle" command
 func NewCommand(settings *environment.Settings) *cobra.Command {
@@ -31,6 +37,7 @@ func NewCommand(settings *environment.Settings) *cobra.Command {
 		NewApproveCommand(settings),
 		NewCommitCommand(settings),
 		NewQueryInstalledCommand(settings),
+		NewQueryApprovedCommand(settings),
 	)
 
 	cmd.SetOutput(settings.Streams.Out)
@@ -83,4 +90,22 @@ func (c *BaseCommand) println(a ...interface{}) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func (c *BaseCommand) print(a ...interface{}) {
+	_, err := fmt.Fprint(c.Settings.Streams.Out, a...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *BaseCommand) printJSONResponse(v interface{}) error {
+	respBytes, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	c.print(string(respBytes))
+
+	return nil
 }

--- a/cmd/commands/lifecycle/queryapproved.go
+++ b/cmd/commands/lifecycle/queryapproved.go
@@ -1,0 +1,130 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle
+
+import (
+	"strconv"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+)
+
+// NewQueryApprovedCommand creates a new "fabric lifecycle queryapproved" command
+func NewQueryApprovedCommand(settings *environment.Settings) *cobra.Command {
+	c := QueryApprovedCommand{}
+
+	c.Settings = settings
+
+	cmd := &cobra.Command{
+		Use:   "queryapproved <channel-id> <chaincode-name> <sequence>",
+		Short: "Query for approved chaincodes",
+		Args:  c.ParseArgs(),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if err := c.Complete(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.Run()
+		},
+	}
+
+	c.AddArg(&c.ChannelID)
+	c.AddArg(&c.ChaincodeName)
+	c.AddArg(&c.Sequence)
+
+	flags := cmd.Flags()
+	flags.StringVar(&c.OutputFormat, "output", "", outputFormatUsage)
+
+	cmd.SetOutput(c.Settings.Streams.Out)
+
+	return cmd
+}
+
+// QueryApprovedCommand implements the chaincode queryapproved command
+type QueryApprovedCommand struct {
+	BaseCommand
+
+	ChannelID     string
+	ChaincodeName string
+	Sequence      string
+	OutputFormat  string
+}
+
+// Validate checks the required parameters for run
+func (c *QueryApprovedCommand) Validate() error {
+	if c.ChannelID == "" {
+		return errors.New("channel ID not specified")
+	}
+
+	if c.ChaincodeName == "" {
+		return errors.New("chaincode name not specified")
+	}
+
+	_, err := strconv.ParseInt(c.Sequence, 10, 64)
+	if err != nil {
+		return errors.WithMessage(err, "invalid sequence")
+	}
+
+	return nil
+}
+
+// Run executes the command
+func (c *QueryApprovedCommand) Run() error {
+	context, err := c.Settings.Config.GetCurrentContext()
+	if err != nil {
+		return err
+	}
+
+	sequence, err := strconv.ParseInt(c.Sequence, 10, 64)
+	if err != nil {
+		return errors.WithMessage(err, "invalid sequence")
+	}
+
+	approvedChaincode, err := c.ResourceManagement.LifecycleQueryApprovedCC(
+		c.ChannelID,
+		resmgmt.LifecycleQueryApprovedCCRequest{
+			Name:     c.ChaincodeName,
+			Sequence: sequence,
+		},
+		resmgmt.WithRetry(retry.DefaultResMgmtOpts),
+		resmgmt.WithTargetEndpoints(context.Peers[0]),
+	)
+	if err != nil {
+		return err
+	}
+
+	if c.OutputFormat == jsonFormat {
+		return c.printJSONResponse(approvedChaincode)
+	}
+
+	return c.printResponse(approvedChaincode)
+}
+
+func (c *QueryApprovedCommand) printResponse(ac resmgmt.LifecycleApprovedChaincodeDefinition) error {
+	c.printf("Name: %s, Version: %s, Package ID: %s, Sequence: %d, Validation Plugin: %s,"+
+		" Endorsement Plugin: %s, Channel Config Policy: %s, Init Required: %t\n",
+		ac.Name, ac.Version, ac.PackageID, ac.Sequence, ac.ValidationPlugin, ac.EndorsementPlugin, ac.ChannelConfigPolicy, ac.InitRequired)
+
+	if len(ac.CollectionConfig) > 0 {
+		for _, collConfig := range ac.CollectionConfig {
+			cfg := collConfig.GetStaticCollectionConfig()
+
+			c.printf("- Collection: %s, Blocks to Live: %d, Maximum Peer Count: %d,"+
+				" Required Peer Count: %d, MemberOnlyRead: %t, cfg.MemberOnlyWrite: %t\n",
+				cfg.Name, cfg.BlockToLive, cfg.MaximumPeerCount, cfg.RequiredPeerCount, cfg.MemberOnlyRead, cfg.MemberOnlyWrite)
+		}
+	}
+
+	return nil
+}

--- a/cmd/commands/lifecycle/queryapproved_test.go
+++ b/cmd/commands/lifecycle/queryapproved_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/cmd/commands/lifecycle"
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric/mocks"
+)
+
+const (
+	queryApprovedPlainTextResponse = "Name: cc1, Version: v1, Package ID: pkg1, Sequence: 1, Validation Plugin: vscc," +
+		" Endorsement Plugin: escc, Channel Config Policy: ccpolicy, Init Required: true\n- Collection: coll1," +
+		" Blocks to Live: 1, Maximum Peer Count: 2, Required Peer Count: 1, MemberOnlyRead: false, cfg.MemberOnlyWrite: false\n"
+	queryApprovedJSONResponse = `{"name":"cc1","version":"v1","sequence":1,"endorsement_plugin":"escc","validation_plugin":"vscc"` +
+		`,"channel_config_policy":"ccpolicy","collection_config":[{"Payload":{"StaticCollectionConfig":` +
+		`{"name":"coll1","required_peer_count":1,"maximum_peer_count":2,"block_to_live":1}}}],"init_required":true,"package_id":"pkg1"}`
+)
+
+var _ = Describe("LifecycleChaincodeQueryApprovedCommand", func() {
+	var (
+		cmd      *cobra.Command
+		settings *environment.Settings
+		out      *bytes.Buffer
+
+		args []string
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		args = os.Args
+	})
+
+	JustBeforeEach(func() {
+		cmd = lifecycle.NewQueryApprovedCommand(settings)
+	})
+
+	AfterEach(func() {
+		os.Args = args
+	})
+
+	It("should create a chaincode 'query approved' command", func() {
+		Expect(cmd.Name()).To(Equal("queryapproved"))
+		Expect(cmd.HasSubCommands()).To(BeFalse())
+	})
+
+	It("should provide a help prompt", func() {
+		os.Args = append(os.Args, "--help")
+
+		Expect(cmd.Execute()).Should(Succeed())
+		Expect(fmt.Sprint(out)).To(ContainSubstring("queryapproved"))
+	})
+})
+
+var _ = Describe("LifecycleChaincodeQueryApprovedImplementation", func() {
+	var (
+		impl     *lifecycle.QueryApprovedCommand
+		err      error
+		out      *bytes.Buffer
+		settings *environment.Settings
+		factory  *mocks.Factory
+		client   *mocks.ResourceManagement
+	)
+
+	BeforeEach(func() {
+		out = new(bytes.Buffer)
+
+		settings = &environment.Settings{
+			Home: environment.Home(os.TempDir()),
+			Streams: environment.Streams{
+				Out: out,
+			},
+		}
+
+		factory = &mocks.Factory{}
+		client = &mocks.ResourceManagement{}
+
+		impl = &lifecycle.QueryApprovedCommand{}
+		impl.Settings = settings
+		impl.Factory = factory
+	})
+
+	It("should not be nil", func() {
+		Expect(impl).ShouldNot(BeNil())
+	})
+
+	Describe("Validate", func() {
+		JustBeforeEach(func() {
+			err = impl.Validate()
+		})
+
+		Context("when channel is not set", func() {
+			It("should fail without channel ID", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("channel ID not specified"))
+			})
+		})
+
+		Context("when chaincode is not set", func() {
+			BeforeEach(func() {
+				impl.ChannelID = "channel1"
+			})
+
+			It("should fail without chaincode", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(Equal("chaincode name not specified"))
+			})
+		})
+
+		Context("when sequence is not set", func() {
+			BeforeEach(func() {
+				impl.ChannelID = "channel1"
+				impl.ChaincodeName = "cc1"
+			})
+
+			It("should fail without sequence", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("invalid sequence"))
+			})
+		})
+
+		Context("when all arguments are set", func() {
+			BeforeEach(func() {
+				impl.ChannelID = "channel1"
+				impl.ChaincodeName = "cc1"
+				impl.Sequence = "1"
+			})
+
+			It("should succeed with all arguments", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Run", func() {
+		BeforeEach(func() {
+			impl.ChannelID = "channel1"
+			impl.ChaincodeName = "cc1"
+			impl.Sequence = "1"
+
+			result := resmgmt.LifecycleApprovedChaincodeDefinition{
+				Name:                "cc1",
+				Version:             "v1",
+				Sequence:            1,
+				PackageID:           "pkg1",
+				ValidationPlugin:    "vscc",
+				EndorsementPlugin:   "escc",
+				ChannelConfigPolicy: "ccpolicy",
+				InitRequired:        true,
+				CollectionConfig: []*pb.CollectionConfig{
+					{
+						Payload: &pb.CollectionConfig_StaticCollectionConfig{
+							StaticCollectionConfig: &pb.StaticCollectionConfig{
+								Name:              "coll1",
+								RequiredPeerCount: 1,
+								MaximumPeerCount:  2,
+								BlockToLive:       1,
+							},
+						},
+					},
+				},
+			}
+
+			client.LifecycleQueryApprovedCCReturns(result, nil)
+			impl.ResourceManagement = client
+		})
+
+		JustBeforeEach(func() {
+			err = impl.Run()
+		})
+
+		Context("when resmgmt client succeeds", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {
+							Peers: []string{"peer1"},
+						},
+					},
+					CurrentContext: "foo",
+				}
+			})
+
+			It("should succeed with plain text response", func() {
+				Expect(err).To(BeNil())
+				Expect(fmt.Sprint(out)).To(Equal(queryApprovedPlainTextResponse))
+			})
+
+			When("the output format is set to json", func() {
+				BeforeEach(func() {
+					impl.OutputFormat = "json"
+				})
+
+				It("should succeed with JSON response", func() {
+					Expect(err).To(BeNil())
+					Expect(fmt.Sprint(out)).To(Equal(queryApprovedJSONResponse))
+				})
+			})
+		})
+
+		Context("when resmgmt client fails", func() {
+			BeforeEach(func() {
+				settings.Config = &environment.Config{
+					Contexts: map[string]*environment.Context{
+						"foo": {
+							Peers: []string{"peer1"},
+						},
+					},
+					CurrentContext: "foo",
+				}
+
+				client.LifecycleQueryApprovedCCReturns(resmgmt.LifecycleApprovedChaincodeDefinition{}, errors.New("query approved error"))
+			})
+
+			It("should fail to query approved chaincodes", func() {
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("query approved error"))
+			})
+		})
+	})
+})

--- a/cmd/commands/lifecycle/queryinstalled.go
+++ b/cmd/commands/lifecycle/queryinstalled.go
@@ -7,9 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package lifecycle
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/resmgmt"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
 	"github.com/pkg/errors"
@@ -17,9 +14,6 @@ import (
 
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 )
-
-const outputFormatUsage = `The output format for query results. If set to 'json' then the response it output in JSON format,
-otherwise the response is output in human-readable text.`
 
 // NewQueryInstalledCommand creates a new "fabric lifecycle queryinstalled" command
 func NewQueryInstalledCommand(settings *environment.Settings) *cobra.Command {
@@ -113,14 +107,4 @@ func (c *QueryInstalledCommand) printReferences(refs map[string][]resmgmt.CCRefe
 			c.printf("--- Name: %s, Version: %s\n", ref.Name, ref.Version)
 		}
 	}
-}
-
-func (c *QueryInstalledCommand) printJSONResponse(installedChaincodes []resmgmt.LifecycleInstalledCC) error {
-	respBytes, err := json.Marshal(installedChaincodes)
-	if err != nil {
-		return err
-	}
-
-	_, err = fmt.Fprint(c.Settings.Streams.Out, string(respBytes))
-	return err
 }

--- a/cmd/commands/lifecycle/queryinstalled_test.go
+++ b/cmd/commands/lifecycle/queryinstalled_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	plainTextResponse = "Installed chaincodes:\n- Package ID: pkg1, Label: label1\n-- References for channel [channel1]:\n--- Name: cc1, Version: v1\n"
-	jsonResponse      = `[{"package_id":"pkg1","label":"label1","references":{"channel1":[{"name":"cc1","version":"v1"}]}}]`
+	queryInstalledPlainTextResponse = "Installed chaincodes:\n- Package ID: pkg1, Label: label1\n-- " +
+		"References for channel [channel1]:\n--- Name: cc1, Version: v1\n"
+	queryInstalledJSONResponse = `[{"package_id":"pkg1","label":"label1","references":{"channel1":[{"name":"cc1","version":"v1"}]}}]`
 )
 
 var _ = Describe("LifecycleChaincodeQueryInstalledCommand", func() {
@@ -170,7 +171,7 @@ var _ = Describe("LifecycleChaincodeQueryInstalledImplementation", func() {
 
 			It("should succeed with plain text response", func() {
 				Expect(err).To(BeNil())
-				Expect(fmt.Sprint(out)).To(Equal(plainTextResponse))
+				Expect(fmt.Sprint(out)).To(Equal(queryInstalledPlainTextResponse))
 			})
 
 			When("the output format is set to json", func() {
@@ -180,7 +181,7 @@ var _ = Describe("LifecycleChaincodeQueryInstalledImplementation", func() {
 
 				It("should succeed with JSON response", func() {
 					Expect(err).To(BeNil())
-					Expect(fmt.Sprint(out)).To(Equal(jsonResponse))
+					Expect(fmt.Sprint(out)).To(Equal(queryInstalledJSONResponse))
 				})
 			})
 		})

--- a/pkg/fabric/interfaces.go
+++ b/pkg/fabric/interfaces.go
@@ -87,6 +87,8 @@ type ResourceManagement interface {
 	LifecycleApproveCC(channelID string, req resmgmt.LifecycleApproveCCRequest, options ...resmgmt.RequestOption) (fab.TransactionID, error)
 	LifecycleCommitCC(channelID string, req resmgmt.LifecycleCommitCCRequest, options ...resmgmt.RequestOption) (fab.TransactionID, error)
 	LifecycleQueryInstalledCC(options ...resmgmt.RequestOption) ([]resmgmt.LifecycleInstalledCC, error)
+	LifecycleQueryApprovedCC(channelID string, req resmgmt.LifecycleQueryApprovedCCRequest,
+		options ...resmgmt.RequestOption) (resmgmt.LifecycleApprovedChaincodeDefinition, error)
 }
 
 // MSP defines the methods implemented by SDK msp client

--- a/pkg/fabric/mocks/resmgmt.go
+++ b/pkg/fabric/mocks/resmgmt.go
@@ -127,6 +127,21 @@ type ResourceManagement struct {
 		result1 []resmgmt.LifecycleInstallCCResponse
 		result2 error
 	}
+	LifecycleQueryApprovedCCStub        func(string, resmgmt.LifecycleQueryApprovedCCRequest, ...resmgmt.RequestOption) (resmgmt.LifecycleApprovedChaincodeDefinition, error)
+	lifecycleQueryApprovedCCMutex       sync.RWMutex
+	lifecycleQueryApprovedCCArgsForCall []struct {
+		arg1 string
+		arg2 resmgmt.LifecycleQueryApprovedCCRequest
+		arg3 []resmgmt.RequestOption
+	}
+	lifecycleQueryApprovedCCReturns struct {
+		result1 resmgmt.LifecycleApprovedChaincodeDefinition
+		result2 error
+	}
+	lifecycleQueryApprovedCCReturnsOnCall map[int]struct {
+		result1 resmgmt.LifecycleApprovedChaincodeDefinition
+		result2 error
+	}
 	LifecycleQueryInstalledCCStub        func(...resmgmt.RequestOption) ([]resmgmt.LifecycleInstalledCC, error)
 	lifecycleQueryInstalledCCMutex       sync.RWMutex
 	lifecycleQueryInstalledCCArgsForCall []struct {
@@ -754,6 +769,71 @@ func (fake *ResourceManagement) LifecycleInstallCCReturnsOnCall(i int, result1 [
 	}{result1, result2}
 }
 
+func (fake *ResourceManagement) LifecycleQueryApprovedCC(arg1 string, arg2 resmgmt.LifecycleQueryApprovedCCRequest, arg3 ...resmgmt.RequestOption) (resmgmt.LifecycleApprovedChaincodeDefinition, error) {
+	fake.lifecycleQueryApprovedCCMutex.Lock()
+	ret, specificReturn := fake.lifecycleQueryApprovedCCReturnsOnCall[len(fake.lifecycleQueryApprovedCCArgsForCall)]
+	fake.lifecycleQueryApprovedCCArgsForCall = append(fake.lifecycleQueryApprovedCCArgsForCall, struct {
+		arg1 string
+		arg2 resmgmt.LifecycleQueryApprovedCCRequest
+		arg3 []resmgmt.RequestOption
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("LifecycleQueryApprovedCC", []interface{}{arg1, arg2, arg3})
+	fake.lifecycleQueryApprovedCCMutex.Unlock()
+	if fake.LifecycleQueryApprovedCCStub != nil {
+		return fake.LifecycleQueryApprovedCCStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.lifecycleQueryApprovedCCReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ResourceManagement) LifecycleQueryApprovedCCCallCount() int {
+	fake.lifecycleQueryApprovedCCMutex.RLock()
+	defer fake.lifecycleQueryApprovedCCMutex.RUnlock()
+	return len(fake.lifecycleQueryApprovedCCArgsForCall)
+}
+
+func (fake *ResourceManagement) LifecycleQueryApprovedCCCalls(stub func(string, resmgmt.LifecycleQueryApprovedCCRequest, ...resmgmt.RequestOption) (resmgmt.LifecycleApprovedChaincodeDefinition, error)) {
+	fake.lifecycleQueryApprovedCCMutex.Lock()
+	defer fake.lifecycleQueryApprovedCCMutex.Unlock()
+	fake.LifecycleQueryApprovedCCStub = stub
+}
+
+func (fake *ResourceManagement) LifecycleQueryApprovedCCArgsForCall(i int) (string, resmgmt.LifecycleQueryApprovedCCRequest, []resmgmt.RequestOption) {
+	fake.lifecycleQueryApprovedCCMutex.RLock()
+	defer fake.lifecycleQueryApprovedCCMutex.RUnlock()
+	argsForCall := fake.lifecycleQueryApprovedCCArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *ResourceManagement) LifecycleQueryApprovedCCReturns(result1 resmgmt.LifecycleApprovedChaincodeDefinition, result2 error) {
+	fake.lifecycleQueryApprovedCCMutex.Lock()
+	defer fake.lifecycleQueryApprovedCCMutex.Unlock()
+	fake.LifecycleQueryApprovedCCStub = nil
+	fake.lifecycleQueryApprovedCCReturns = struct {
+		result1 resmgmt.LifecycleApprovedChaincodeDefinition
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ResourceManagement) LifecycleQueryApprovedCCReturnsOnCall(i int, result1 resmgmt.LifecycleApprovedChaincodeDefinition, result2 error) {
+	fake.lifecycleQueryApprovedCCMutex.Lock()
+	defer fake.lifecycleQueryApprovedCCMutex.Unlock()
+	fake.LifecycleQueryApprovedCCStub = nil
+	if fake.lifecycleQueryApprovedCCReturnsOnCall == nil {
+		fake.lifecycleQueryApprovedCCReturnsOnCall = make(map[int]struct {
+			result1 resmgmt.LifecycleApprovedChaincodeDefinition
+			result2 error
+		})
+	}
+	fake.lifecycleQueryApprovedCCReturnsOnCall[i] = struct {
+		result1 resmgmt.LifecycleApprovedChaincodeDefinition
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ResourceManagement) LifecycleQueryInstalledCC(arg1 ...resmgmt.RequestOption) ([]resmgmt.LifecycleInstalledCC, error) {
 	fake.lifecycleQueryInstalledCCMutex.Lock()
 	ret, specificReturn := fake.lifecycleQueryInstalledCCReturnsOnCall[len(fake.lifecycleQueryInstalledCCArgsForCall)]
@@ -1284,6 +1364,8 @@ func (fake *ResourceManagement) Invocations() map[string][][]interface{} {
 	defer fake.lifecycleCommitCCMutex.RUnlock()
 	fake.lifecycleInstallCCMutex.RLock()
 	defer fake.lifecycleInstallCCMutex.RUnlock()
+	fake.lifecycleQueryApprovedCCMutex.RLock()
+	defer fake.lifecycleQueryApprovedCCMutex.RUnlock()
 	fake.lifecycleQueryInstalledCCMutex.RLock()
 	defer fake.lifecycleQueryInstalledCCMutex.RUnlock()
 	fake.queryChannelsMutex.RLock()


### PR DESCRIPTION
The queryapproved command queries a peer for approved chaincodes.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>