### PR TITLE
[FAB-18296] Changed sequence to be optional for lifecycle queryapproved

### DIFF
--- a/cmd/commands/lifecycle/queryapproved_test.go
+++ b/cmd/commands/lifecycle/queryapproved_test.go
@@ -119,12 +119,13 @@ var _ = Describe("LifecycleChaincodeQueryApprovedImplementation", func() {
 			})
 		})
 
-		Context("when sequence is not set", func() {
+		Context("when invalid sequence is set", func() {
 			BeforeEach(func() {
 				impl.ChaincodeName = "cc1"
+				impl.Sequence = "xxx"
 			})
 
-			It("should fail without sequence", func() {
+			It("should fail with invalid sequence", func() {
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("invalid sequence"))
 			})


### PR DESCRIPTION
The sequence number is no longer required for the 'lifecycle queryapproved' command. The sequence number is now specified as a flag: --sequence <seq-num>. If not provided then the latest sequence is used.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>