### PR TITLE
[FAB-18295] Add 'is-init' flag for the 'chaincode invoke' command

### DIFF
--- a/cmd/commands/chaincode/invoke.go
+++ b/cmd/commands/chaincode/invoke.go
@@ -50,6 +50,7 @@ func NewChaincodeInvokeCommand(settings *environment.Settings) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&c.ChaincodeFcn, "fcn", "", "set the invoke function")
 	flags.StringArrayVar(&c.ChaincodeArgs, "args", []string{}, "set the invoke arguments")
+	flags.BoolVar(&c.IsInit, "is-init", false, "indicates whether or not this invocation is meant to initialize the chaincode")
 
 	cmd.SetOutput(c.Settings.Streams.Out)
 
@@ -64,6 +65,7 @@ type InvokeCommand struct {
 
 	ChaincodeFcn  string
 	ChaincodeArgs []string
+	IsInit        bool
 }
 
 // Validate checks the required parameters for run
@@ -77,10 +79,16 @@ func (c *InvokeCommand) Validate() error {
 
 // Run executes the command
 func (c *InvokeCommand) Run() error {
+	fcn := c.ChaincodeFcn
+	if c.IsInit {
+		fcn = "Init"
+	}
+
 	req := channel.Request{
 		ChaincodeID: c.ChaincodeName,
-		Fcn:         c.ChaincodeFcn,
+		Fcn:         fcn,
 		Args:        common.AsByteArgs(c.ChaincodeArgs),
+		IsInit:      c.IsInit,
 	}
 
 	resp, err := c.Channel.Execute(req, channel.WithRetry(retry.DefaultChannelOpts))

--- a/cmd/commands/chaincode/invoke_test.go
+++ b/cmd/commands/chaincode/invoke_test.go
@@ -116,6 +116,17 @@ var _ = Describe("ChaincodeInvokeImplementation", func() {
 				Expect(err).To(BeNil())
 			})
 		})
+
+		Context("when --is-init is set", func() {
+			BeforeEach(func() {
+				impl.ChaincodeName = "mycc"
+				impl.IsInit = true
+			})
+
+			It("should succeed with chaincode name is set", func() {
+				Expect(err).To(BeNil())
+			})
+		})
 	})
 
 	Describe("Run", func() {


### PR DESCRIPTION
The 'is-init' flag, when set to true, invokes the 'Init' function of the chaincode.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>