### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,11 +3,16 @@ Maintainers
 
 fabric-cli uses a non-author code review policy, requiring a single approval from a non-author maintainer.
 
+**Active maintainers**
 | Name | GitHub | Chat | email |
 |------|--------|------|-------|
 | Arnaud Le Hors | [lehors](https://github.com/lehors) | lehors | <lehors@us.ibm.com> |
-| Brian Buchanan | [bpbuch](https://github.com/bpbuch) | bpbuch | <bbuchanan@salesforce.com> |
 | Troy Ronda | [troyronda](https://github.com/troyronda) | troyronda | <troy@troyronda.com> |
 
+**Emeritus maintainers**
+
+| Name | GitHub | Chat | email |
+|------|--------|------|-------|
+| Brian Buchanan | [bpbuch](https://github.com/bpbuch) | bpbuch | <bbuchanan@salesforce.com> |
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>