### PR TITLE
Add missing properties to collections generation from bytes

### DIFF
--- a/cmd/commands/common/common.go
+++ b/cmd/commands/common/common.go
@@ -61,6 +61,9 @@ func GetCollectionsConfigFromBytes(bytes []byte) ([]*pb.CollectionConfig, error)
 					MemberOrgsPolicy:  cpc,
 					RequiredPeerCount: cconfitem.RequiredCount,
 					MaximumPeerCount:  cconfitem.MaxPeerCount,
+					MemberOnlyRead:    cconfitem.MemberOnlyRead,
+					MemberOnlyWrite:   cconfitem.MemberOnlyWrite,
+					BlockToLive:       cconfitem.BlockToLive,
 				},
 			},
 		}


### PR DESCRIPTION
In function `GetCollectionsConfigFromBytes`, it was not possible to get a config file with properties `MemberOnlyRead`, `MemberOnlyWrite` and `BlockToLive` even though protos types had the types.

With this PR, the missing properties are now filled for the proto generation.